### PR TITLE
configure `ruff` to auto-fix isort linting errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,7 @@ repos:
     rev: v0.1.6
     hooks:
       - id: ruff
+        args: [--fix]
   - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 23.11.0
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,9 @@ select = [
 ]
 line-length = 100
 
+[tool.ruff.lint]
+fixable = ["I"]
+
 [tool.ruff.isort]
 known-first-party = ["xdggs"]
 known-third-party=[


### PR DESCRIPTION
While auto-fixing all errors is too much, `isort` is something that is tricky to change manually (plus, the error message is too generic to even know why it's complaining).