### PR TITLE
move towards grid objects

### DIFF
--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -10,6 +10,7 @@ dependencies:
   - matplotlib-base
   - shapely
   - pytest
+  - hypothesis
   - ruff
   - pip
   - pip:

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -12,6 +12,7 @@ dependencies:
   - pytest
   - hypothesis
   - ruff
+  - typing-extensions
   - pip
   - pip:
       - h3ronpy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "xarray",
     "healpy",
     "h3ronpy",
+    "typing-extensions",
 ]
 
 [project.urls]
@@ -44,7 +45,7 @@ dependencies = [
 Repository = "https://github.com/xarray-contrib/xdggs"
 
 [tool.ruff]
-target-version = "py311"
+target-version = "py310"
 builtins = ["ellipsis"]
 exclude = [
     ".git",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,3 +85,11 @@ known-third-party=[
     "healpy",
     "h3ronpy",
 ]
+
+[tool.coverage.run]
+source = ["xdggs"]
+branch = true
+
+[tool.coverage.report]
+show_missing = true
+exclude_lines = ["pragma: no cover", "if TYPE_CHECKING"]

--- a/xdggs/__init__.py
+++ b/xdggs/__init__.py
@@ -1,13 +1,13 @@
 from importlib.metadata import PackageNotFoundError, version
 
-from xdggs.accessor import DGGSAccessor  # noqa
+from xdggs.accessor import DGGSAccessor  # noqa: F401
 from xdggs.h3 import H3Index
 from xdggs.healpix import HealpixIndex
 from xdggs.index import DGGSIndex, decode
 
 try:
     __version__ = version("xdggs")
-except PackageNotFoundError:  # noqa
+except PackageNotFoundError:  # noqa # pragma: no cover
     # package is not installed
     __version__ = "9999"
 

--- a/xdggs/accessor.py
+++ b/xdggs/accessor.py
@@ -50,6 +50,11 @@ class DGGSAccessor:
             )
         return self._obj[self._name]
 
+    @property
+    def params(self) -> dict:
+        """The grid parameters after normalization."""
+        return self.index.grid.to_dict()
+
     def sel_latlon(
         self, latitude: npt.ArrayLike, longitude: npt.ArrayLike
     ) -> xr.Dataset | xr.DataArray:

--- a/xdggs/accessor.py
+++ b/xdggs/accessor.py
@@ -81,7 +81,7 @@ class DGGSAccessor:
         """Return a new Dataset or DataArray with new "latitude" and "longitude"
         coordinates representing the grid cell centers."""
 
-        lat_data, lon_data = self.index.cell_centers
+        lon_data, lat_data = self.index.cell_centers
         return self._obj.assign_coords(
             latitude=(self.index._dim, lat_data),
             longitude=(self.index._dim, lon_data),

--- a/xdggs/grid.py
+++ b/xdggs/grid.py
@@ -6,6 +6,14 @@ T = TypeVar("T")
 
 @dataclass(frozen=True)
 class DGGSInfo:
+    """Base class for DGGS grid information objects
+
+    Parameters
+    ----------
+    resolution : int
+        The resolution of the grid.
+    """
+
     resolution: int
 
     @classmethod

--- a/xdggs/grid.py
+++ b/xdggs/grid.py
@@ -3,7 +3,7 @@ from typing import Any, TypeVar
 
 try:
     from typing import Self
-except ImportError:
+except ImportError:  # pragma: no cover
     from typing_extensions import Self
 
 T = TypeVar("T")

--- a/xdggs/grid.py
+++ b/xdggs/grid.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import TypeVar
+from typing import Any, Self, TypeVar
 
 T = TypeVar("T")
 
@@ -9,5 +9,8 @@ class DGGSInfo:
     resolution: int
 
     @classmethod
-    def from_dict(cls: type[T], mapping: dict) -> T:
+    def from_dict(cls: type[T], mapping: dict[str, Any]) -> T:
         return cls(**mapping)
+
+    def to_dict(self: Self) -> dict[str, Any]:
+        return {"resolution": self.resolution}

--- a/xdggs/grid.py
+++ b/xdggs/grid.py
@@ -1,5 +1,10 @@
 from dataclasses import dataclass
-from typing import Any, Self, TypeVar
+from typing import Any, TypeVar
+
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 T = TypeVar("T")
 

--- a/xdggs/h3.py
+++ b/xdggs/h3.py
@@ -38,16 +38,16 @@ class H3Info(DGGSInfo):
 
 @register_dggs("h3")
 class H3Index(DGGSIndex):
-    _resolution: int
+    _grid: DGGSInfo
 
     def __init__(
         self,
         cell_ids: Any | PandasIndex,
         dim: str,
-        resolution: int,
+        grid_info: DGGSInfo,
     ):
         super().__init__(cell_ids, dim)
-        self._resolution = int(resolution)
+        self._grid = grid_info
 
     @classmethod
     def from_variables(
@@ -58,17 +58,18 @@ class H3Index(DGGSIndex):
     ) -> "H3Index":
         _, var, dim = _extract_cell_id_variable(variables)
 
-        resolution = var.attrs.get("resolution", options.get("resolution"))
-        return cls(var.data, dim, resolution)
+        grid_info = H3Info.from_dict(var.attrs | options)
+
+        return cls(var.data, dim, grid_info)
 
     def _replace(self, new_pd_index: PandasIndex):
-        return type(self)(new_pd_index, self._dim, self._resolution)
+        return type(self)(new_pd_index, self._dim, self._grid)
 
     def _latlon2cellid(self, lat: Any, lon: Any) -> np.ndarray:
-        return coordinates_to_cells(lat, lon, self._resolution, radians=False)
+        return coordinates_to_cells(lat, lon, self._grid.resolution, radians=False)
 
     def _cellid2latlon(self, cell_ids: Any) -> tuple[np.ndarray, np.ndarray]:
         return cells_to_coordinates(cell_ids, radians=False)
 
     def _repr_inline_(self, max_width: int):
-        return f"H3Index(resolution={self._resolution})"
+        return f"H3Index(resolution={self._grid.resolution})"

--- a/xdggs/h3.py
+++ b/xdggs/h3.py
@@ -62,6 +62,10 @@ class H3Index(DGGSIndex):
 
         return cls(var.data, dim, grid_info)
 
+    @property
+    def grid(self) -> H3Info:
+        return self._grid
+
     def _replace(self, new_pd_index: PandasIndex):
         return type(self)(new_pd_index, self._dim, self._grid)
 

--- a/xdggs/h3.py
+++ b/xdggs/h3.py
@@ -4,7 +4,7 @@ from typing import Any, ClassVar
 
 try:
     from typing import Self
-except ImportError:
+except ImportError:  # pragma: no cover
     from typing_extensions import Self
 
 import numpy as np

--- a/xdggs/h3.py
+++ b/xdggs/h3.py
@@ -46,8 +46,7 @@ class H3Index(DGGSIndex):
         dim: str,
         grid_info: DGGSInfo,
     ):
-        super().__init__(cell_ids, dim)
-        self._grid = grid_info
+        super().__init__(cell_ids, dim, grid_info)
 
     @classmethod
     def from_variables(

--- a/xdggs/h3.py
+++ b/xdggs/h3.py
@@ -63,7 +63,7 @@ class H3Index(DGGSIndex):
         return cls(var.data, dim, grid_info)
 
     @property
-    def grid(self) -> H3Info:
+    def grid_info(self) -> H3Info:
         return self._grid
 
     def _replace(self, new_pd_index: PandasIndex):

--- a/xdggs/healpix.py
+++ b/xdggs/healpix.py
@@ -84,7 +84,7 @@ class HealpixInfo(DGGSInfo):
 
     def to_dict(self: Self) -> dict[str, Any]:
         return {
-            "grid_type": "healpix",
+            "grid_name": "healpix",
             "resolution": self.resolution,
             "indexing_scheme": self.indexing_scheme,
             "rotation": list(self.rotation),

--- a/xdggs/healpix.py
+++ b/xdggs/healpix.py
@@ -32,7 +32,7 @@ class HealpixInfo(DGGSInfo):
     def nest(self: Self) -> bool:
         if self.indexing_scheme not in {"nested", "ring"}:
             raise ValueError(
-                f"cannot convert index scheme {self.indexing_scheme} to `nest`"
+                f"cannot convert indexing scheme {self.indexing_scheme} to `nest`"
             )
         else:
             return self.indexing_scheme == "nested"

--- a/xdggs/healpix.py
+++ b/xdggs/healpix.py
@@ -168,8 +168,8 @@ class HealpixIndex(DGGSIndex):
         lon, lat = healpy.pix2ang(
             self._grid.nside, cell_ids, nest=self._grid.nest, lonlat=True
         )
-        # TODO: apply rotation
-        return np.stack([lon, lat], axis=-1)
+
+        return lon, lat
 
     @property
     def grid(self) -> HealpixInfo:

--- a/xdggs/healpix.py
+++ b/xdggs/healpix.py
@@ -87,7 +87,7 @@ class HealpixInfo(DGGSInfo):
             "grid_name": "healpix",
             "resolution": self.resolution,
             "indexing_scheme": self.indexing_scheme,
-            "rotation": list(self.rotation),
+            "rotation": self.rotation,
         }
 
 

--- a/xdggs/healpix.py
+++ b/xdggs/healpix.py
@@ -58,8 +58,16 @@ class HealpixInfo(DGGSInfo):
 
     @classmethod
     def from_dict(cls: type[T], mapping: dict[str, Any]) -> T:
+        def translate_nside(nside):
+            log = np.log2(nside)
+            potential_resolution = int(log)
+            if potential_resolution != log:
+                raise ValueError("`nside` has to be an integer power of 2")
+
+            return potential_resolution
+
         translations = {
-            "nside": ("resolution", lambda nside: int(np.log2(nside))),
+            "nside": ("resolution", translate_nside),
             "order": ("resolution", identity),
             "level": ("resolution", identity),
             "depth": ("resolution", identity),

--- a/xdggs/healpix.py
+++ b/xdggs/healpix.py
@@ -1,20 +1,23 @@
 import operator
 from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any, Literal
+from typing import Any, Literal, Self, TypeVar
 
 import healpy
 import numpy as np
 import xarray as xr
 from xarray.indexes import PandasIndex
 
+from xdggs.grid import DGGSInfo
 from xdggs.index import DGGSIndex
 from xdggs.itertools import groupby, identity
 from xdggs.utils import _extract_cell_id_variable, register_dggs
 
+T = TypeVar("T")
+
 
 @dataclass(frozen=True)
-class HealpixInfo:
+class HealpixInfo(DGGSInfo):
     resolution: int
 
     indexing_scheme: Literal["nested", "ring", "unique"] = "nested"
@@ -22,11 +25,11 @@ class HealpixInfo:
     rotation: tuple[float, float] = (0.0, 0.0)
 
     @property
-    def nside(self):
+    def nside(self: Self) -> int:
         return 2**self.resolution
 
     @property
-    def nest(self):
+    def nest(self: Self) -> bool:
         if self.indexing_scheme not in {"nested", "ring"}:
             raise ValueError(
                 f"cannot convert index scheme {self.indexing_scheme} to `nest`"
@@ -35,7 +38,7 @@ class HealpixInfo:
             return self.indexing_scheme == "nested"
 
     @classmethod
-    def from_dict(cls, mapping):
+    def from_dict(cls: type[T], mapping: dict[str, Any]) -> T:
         translations = {
             "nside": ("resolution", lambda nside: int(np.log2(nside))),
             "order": ("resolution", identity),
@@ -79,7 +82,7 @@ class HealpixInfo:
 
         return cls(**params)
 
-    def to_dict(self):
+    def to_dict(self: Self) -> dict[str, Any]:
         return {
             "grid_type": "healpix",
             "resolution": self.resolution,

--- a/xdggs/healpix.py
+++ b/xdggs/healpix.py
@@ -97,9 +97,12 @@ class HealpixIndex(DGGSIndex):
         self,
         cell_ids: Any | PandasIndex,
         dim: str,
-        grid_info,
+        grid_info: DGGSInfo,
     ):
         super().__init__(cell_ids, dim)
+
+        if not isinstance(grid_info, HealpixInfo):
+            raise ValueError(f"grid info object has an invalid type: {type(grid_info)}")
         self._grid = grid_info
 
     @classmethod

--- a/xdggs/healpix.py
+++ b/xdggs/healpix.py
@@ -164,7 +164,7 @@ class HealpixIndex(DGGSIndex):
             self._grid.nside, cell_ids, nest=self._grid.nest, lonlat=True
         )
         # TODO: apply rotation
-        return np.stack([lon, lat], axis=0)
+        return np.stack([lon, lat], axis=-1)
 
     def _repr_inline_(self, max_width: int):
         return f"HealpixIndex(nside={self._grid.resolution}, indexing_scheme={self._grid.indexing_scheme}, rotation={self._grid.rotation!r})"

--- a/xdggs/healpix.py
+++ b/xdggs/healpix.py
@@ -38,6 +38,11 @@ class HealpixInfo(DGGSInfo):
                 f"indexing scheme must be one of {self.valid_parameters['indexing_scheme']}"
             )
 
+        if np.any(np.isnan(self.rotation) | np.isinf(self.rotation)):
+            raise ValueError(
+                f"rotation must consist of finite values, got {self.rotation}"
+            )
+
     @property
     def nside(self: Self) -> int:
         return 2**self.resolution

--- a/xdggs/healpix.py
+++ b/xdggs/healpix.py
@@ -1,7 +1,12 @@
 import operator
 from collections.abc import Mapping
 from dataclasses import dataclass, field
-from typing import Any, ClassVar, Literal, Self, TypeVar
+from typing import Any, ClassVar, Literal, TypeVar
+
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 import healpy
 import numpy as np

--- a/xdggs/healpix.py
+++ b/xdggs/healpix.py
@@ -102,7 +102,7 @@ class HealpixInfo(DGGSInfo):
                 "received multiple values for parameters",
                 [
                     ValueError(
-                        f"Parameter {name} received multiple values: {[n for n, _ in group]}"
+                        f"Parameter {name} received multiple values: {sorted(n for n, _ in group)}"
                     )
                     for name, group in duplicated_parameters.items()
                 ],

--- a/xdggs/healpix.py
+++ b/xdggs/healpix.py
@@ -136,11 +136,10 @@ class HealpixIndex(DGGSIndex):
         dim: str,
         grid_info: DGGSInfo,
     ):
-        super().__init__(cell_ids, dim)
-
         if not isinstance(grid_info, HealpixInfo):
             raise ValueError(f"grid info object has an invalid type: {type(grid_info)}")
-        self._grid = grid_info
+
+        super().__init__(cell_ids, dim, grid_info)
 
     @classmethod
     def from_variables(

--- a/xdggs/healpix.py
+++ b/xdggs/healpix.py
@@ -171,5 +171,9 @@ class HealpixIndex(DGGSIndex):
         # TODO: apply rotation
         return np.stack([lon, lat], axis=-1)
 
+    @property
+    def grid(self) -> HealpixInfo:
+        return self._grid
+
     def _repr_inline_(self, max_width: int):
         return f"HealpixIndex(nside={self._grid.resolution}, indexing_scheme={self._grid.indexing_scheme}, rotation={self._grid.rotation!r})"

--- a/xdggs/healpix.py
+++ b/xdggs/healpix.py
@@ -24,6 +24,15 @@ class HealpixInfo(DGGSInfo):
 
     rotation: tuple[float, float] = (0.0, 0.0)
 
+    def __post_init__(self):
+        if self.resolution < 0 or self.resolution > 29:
+            raise ValueError("resolution must be an integer in the range of [0, 29]")
+
+        if self.indexing_scheme not in {"nested", "ring", "unique"}:
+            raise ValueError(
+                "indexing scheme must be one of ['nested', 'ring', 'unique']"
+            )
+
     @property
     def nside(self: Self) -> int:
         return 2**self.resolution

--- a/xdggs/healpix.py
+++ b/xdggs/healpix.py
@@ -172,7 +172,7 @@ class HealpixIndex(DGGSIndex):
         return lon, lat
 
     @property
-    def grid(self) -> HealpixInfo:
+    def grid_info(self) -> HealpixInfo:
         return self._grid
 
     def _repr_inline_(self, max_width: int):

--- a/xdggs/healpix.py
+++ b/xdggs/healpix.py
@@ -19,20 +19,23 @@ T = TypeVar("T")
 @dataclass(frozen=True)
 class HealpixInfo(DGGSInfo):
     resolution: int
-    valid_resolutions: ClassVar[range] = range(0, 29)
 
     indexing_scheme: Literal["nested", "ring", "unique"] = "nested"
-    valid_indexing_schemes: ClassVar[list[str]] = ["nested", "ring", "unique"]
 
     rotation: list[float, float] = field(default_factory=lambda: [0.0, 0.0])
 
+    valid_parameters: ClassVar[dict[str, Any]] = {
+        "resolution": range(0, 29 + 1),
+        "indexing_scheme": ["nested", "ring", "unique"],
+    }
+
     def __post_init__(self):
-        if self.resolution < 0 or self.resolution > 29:
+        if self.resolution not in self.valid_parameters["resolution"]:
             raise ValueError("resolution must be an integer in the range of [0, 29]")
 
-        if self.indexing_scheme not in {"nested", "ring", "unique"}:
+        if self.indexing_scheme not in self.valid_parameters["indexing_scheme"]:
             raise ValueError(
-                "indexing scheme must be one of ['nested', 'ring', 'unique']"
+                f"indexing scheme must be one of {self.valid_parameters['indexing_scheme']}"
             )
 
     @property

--- a/xdggs/healpix.py
+++ b/xdggs/healpix.py
@@ -5,7 +5,7 @@ from typing import Any, ClassVar, Literal, TypeVar
 
 try:
     from typing import Self
-except ImportError:
+except ImportError:  # pragma: no cover
     from typing_extensions import Self
 
 import healpy
@@ -22,7 +22,7 @@ T = TypeVar("T")
 
 try:
     ExceptionGroup
-except NameError:
+except NameError:  # pragma: no cover
     from exceptiongroup import ExceptionGroup
 
 

--- a/xdggs/healpix.py
+++ b/xdggs/healpix.py
@@ -1,6 +1,6 @@
 import operator
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, ClassVar, Literal, Self, TypeVar
 
 import healpy
@@ -24,7 +24,7 @@ class HealpixInfo(DGGSInfo):
     indexing_scheme: Literal["nested", "ring", "unique"] = "nested"
     valid_indexing_schemes: ClassVar[list[str]] = ["nested", "ring", "unique"]
 
-    rotation: tuple[float, float] = (0.0, 0.0)
+    rotation: list[float, float] = field(default_factory=lambda: [0.0, 0.0])
 
     def __post_init__(self):
         if self.resolution < 0 or self.resolution > 29:

--- a/xdggs/healpix.py
+++ b/xdggs/healpix.py
@@ -1,7 +1,7 @@
 import operator
 from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any, Literal, Self, TypeVar
+from typing import Any, ClassVar, Literal, Self, TypeVar
 
 import healpy
 import numpy as np
@@ -19,8 +19,10 @@ T = TypeVar("T")
 @dataclass(frozen=True)
 class HealpixInfo(DGGSInfo):
     resolution: int
+    valid_resolutions: ClassVar[range] = range(0, 29)
 
     indexing_scheme: Literal["nested", "ring", "unique"] = "nested"
+    valid_indexing_schemes: ClassVar[list[str]] = ["nested", "ring", "unique"]
 
     rotation: tuple[float, float] = (0.0, 0.0)
 

--- a/xdggs/healpix.py
+++ b/xdggs/healpix.py
@@ -20,6 +20,11 @@ from xdggs.utils import _extract_cell_id_variable, register_dggs
 
 T = TypeVar("T")
 
+try:
+    ExceptionGroup
+except NameError:
+    from exceptiongroup import ExceptionGroup
+
 
 @dataclass(frozen=True)
 class HealpixInfo(DGGSInfo):

--- a/xdggs/index.py
+++ b/xdggs/index.py
@@ -80,3 +80,7 @@ class DGGSIndex(Index):
     @property
     def cell_centers(self) -> tuple[np.ndarray, np.ndarray]:
         return self._cellid2latlon(self._pd_index.index.values)
+
+    @property
+    def grid_info(self) -> DGGSInfo:
+        return self._grid

--- a/xdggs/index.py
+++ b/xdggs/index.py
@@ -38,7 +38,9 @@ class DGGSIndex(Index):
         _, var, _ = _extract_cell_id_variable(variables)
 
         grid_name = var.attrs["grid_name"]
-        cls = GRID_REGISTRY[grid_name]
+        cls = GRID_REGISTRY.get(grid_name)
+        if cls is None:
+            raise ValueError(f"unknown DGGS grid name: {grid_name}")
 
         return cls.from_variables(variables, options=options)
 

--- a/xdggs/index.py
+++ b/xdggs/index.py
@@ -5,6 +5,7 @@ import numpy as np
 import xarray as xr
 from xarray.indexes import Index, PandasIndex
 
+from xdggs.grid import DGGSInfo
 from xdggs.utils import GRID_REGISTRY, _extract_cell_id_variable
 
 
@@ -20,13 +21,15 @@ class DGGSIndex(Index):
     _dim: str
     _pd_index: PandasIndex
 
-    def __init__(self, cell_ids: Any | PandasIndex, dim: str):
+    def __init__(self, cell_ids: Any | PandasIndex, dim: str, grid_info: DGGSInfo):
         self._dim = dim
 
         if isinstance(cell_ids, PandasIndex):
             self._pd_index = cell_ids
         else:
             self._pd_index = PandasIndex(cell_ids, dim)
+
+        self._grid = grid_info
 
     @classmethod
     def from_variables(

--- a/xdggs/itertools.py
+++ b/xdggs/itertools.py
@@ -1,9 +1,17 @@
 import itertools
 
 
+def first(x):
+    return x[0]
+
+
 def identity(x):
     return x
 
 
 def groupby(iterable, key):
-    return itertools.groupby(sorted(iterable, key=key), key=key)
+    # to avoid re-evaluating `key` twice for each item, which might be expensive
+    applied = ((key(item), item) for item in iterable)
+    sorted_ = sorted(applied, key=first)
+
+    return itertools.groupby(sorted_, key=first)

--- a/xdggs/itertools.py
+++ b/xdggs/itertools.py
@@ -1,17 +1,9 @@
 import itertools
 
 
-def first(x):
-    return x[0]
-
-
 def identity(x):
     return x
 
 
 def groupby(iterable, key):
-    # to avoid re-evaluating `key` twice for each item, which might be expensive
-    applied = ((key(item), item) for item in iterable)
-    sorted_ = sorted(applied, key=first)
-
-    return itertools.groupby(sorted_, key=first)
+    return itertools.groupby(sorted(iterable, key=key), key=key)

--- a/xdggs/tests/__init__.py
+++ b/xdggs/tests/__init__.py
@@ -1,35 +1,5 @@
-import enum
-import re
-from dataclasses import dataclass, field
-
-try:
-    ExceptionGroup
-except NameError:  # pragma: no cover
-    from exceptiongroup import ExceptionGroup
-
-
-class MatchResult(enum.Enum):
-    match = 0
-    mismatched_typing = 1
-    mismatched_message = 2
-
-
-# necessary until pytest-dev/pytest#11538 is resolved
-@dataclass
-class Match:
-    exc: Exception | ExceptionGroup
-    submatchers: list = field(default_factory=list)
-    match: str = None
-
-    def __post_init__(self):
-        if not isinstance(self.exc, ExceptionGroup) and self.submatchers:
-            raise TypeError("can only pass sub-matchers for exception groups")
-
-    def assert_match(self, exc):
-        assert type(exc) is type(self.exc)  # noqa: E721
-
-        assert re.search(str(exc), self.match), "message does not match"
-
-
-def assert_exceptions_equal(actual, expected):
-    assert type(actual) is type(expected)
+from xdggs.tests.matchers import (  # noqa: F401
+    Match,
+    MatchResult,
+    assert_exceptions_equal,
+)

--- a/xdggs/tests/__init__.py
+++ b/xdggs/tests/__init__.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 
 try:
     ExceptionGroup
-except NameError:
+except NameError:  # pragma: no cover
     from exceptiongroup import ExceptionGroup
 
 

--- a/xdggs/tests/__init__.py
+++ b/xdggs/tests/__init__.py
@@ -2,6 +2,11 @@ import enum
 import re
 from dataclasses import dataclass, field
 
+try:
+    ExceptionGroup
+except NameError:
+    from exceptiongroup import ExceptionGroup
+
 
 class MatchResult(enum.Enum):
     match = 0

--- a/xdggs/tests/__init__.py
+++ b/xdggs/tests/__init__.py
@@ -1,0 +1,30 @@
+import enum
+import re
+from dataclasses import dataclass, field
+
+
+class MatchResult(enum.Enum):
+    match = 0
+    mismatched_typing = 1
+    mismatched_message = 2
+
+
+# necessary until pytest-dev/pytest#11538 is resolved
+@dataclass
+class Match:
+    exc: Exception | ExceptionGroup
+    submatchers: list = field(default_factory=list)
+    match: str = None
+
+    def __post_init__(self):
+        if not isinstance(self.exc, ExceptionGroup) and self.submatchers:
+            raise TypeError("can only pass sub-matchers for exception groups")
+
+    def assert_match(self, exc):
+        assert type(exc) is type(self.exc)  # noqa: E721
+
+        assert re.search(str(exc), self.match), "message does not match"
+
+
+def assert_exceptions_equal(actual, expected):
+    assert type(actual) is type(expected)

--- a/xdggs/tests/test_h3.py
+++ b/xdggs/tests/test_h3.py
@@ -97,9 +97,10 @@ class TestH3Info:
 @pytest.mark.parametrize("dim", dims)
 @pytest.mark.parametrize("cell_ids", cell_ids)
 def test_init(cell_ids, dim, resolution):
-    index = h3.H3Index(cell_ids, dim, resolution)
+    grid = h3.H3Info(resolution)
+    index = h3.H3Index(cell_ids, dim, grid)
 
-    assert index._resolution == resolution
+    assert index._grid == grid
     assert index._dim == dim
 
     # TODO: how do we check the index, if at all?
@@ -116,7 +117,7 @@ def test_from_variables(variable_name, variable, options):
     variables = {variable_name: variable}
     index = h3.H3Index.from_variables(variables, options=options)
 
-    assert index._resolution == expected_resolution
+    assert index._grid.resolution == expected_resolution
     assert (index._dim,) == variable.dims
 
     # TODO: how do we check the index, if at all?
@@ -126,10 +127,11 @@ def test_from_variables(variable_name, variable, options):
 
 @pytest.mark.parametrize(["old_variable", "new_variable"], variable_combinations)
 def test_replace(old_variable, new_variable):
+    grid = h3.H3Info(resolution=old_variable.attrs["resolution"])
     index = h3.H3Index(
         cell_ids=old_variable.data,
         dim=old_variable.dims[0],
-        resolution=old_variable.attrs["resolution"],
+        grid_info=grid,
     )
     new_pandas_index = PandasIndex.from_variables(
         {"cell_ids": new_variable}, options={}
@@ -137,7 +139,7 @@ def test_replace(old_variable, new_variable):
 
     new_index = index._replace(new_pandas_index)
 
-    assert new_index._resolution == index._resolution
+    assert new_index._grid == index._grid
     assert new_index._dim == index._dim
     assert new_index._pd_index == new_pandas_index
 
@@ -146,7 +148,8 @@ def test_replace(old_variable, new_variable):
     ["cell_ids", "cell_centers"], list(zip(cell_ids, cell_centers))
 )
 def test_cellid2latlon(cell_ids, cell_centers):
-    index = h3.H3Index(cell_ids=cell_ids, dim="cells", resolution=3)
+    grid = h3.H3Info(resolution=3)
+    index = h3.H3Index(cell_ids=cell_ids, dim="cells", grid_info=grid)
 
     actual = index._cellid2latlon(cell_ids)
     expected = cell_centers
@@ -158,7 +161,8 @@ def test_cellid2latlon(cell_ids, cell_centers):
     ["cell_centers", "cell_ids"], list(zip(cell_centers, cell_ids))
 )
 def test_latlon2cellid(cell_centers, cell_ids):
-    index = h3.H3Index(cell_ids=[0], dim="cells", resolution=3)
+    grid = h3.H3Info(resolution=3)
+    index = h3.H3Index(cell_ids=[0], dim="cells", grid_info=grid)
 
     actual = index._latlon2cellid(cell_centers[:, 0], cell_centers[:, 1])
     expected = cell_ids
@@ -169,7 +173,8 @@ def test_latlon2cellid(cell_centers, cell_ids):
 @pytest.mark.parametrize("max_width", [20, 50, 80, 120])
 @pytest.mark.parametrize("resolution", resolutions)
 def test_repr_inline(resolution, max_width):
-    index = h3.H3Index(cell_ids=[0], dim="cells", resolution=resolution)
+    grid = h3.H3Info(resolution=resolution)
+    index = h3.H3Index(cell_ids=[0], dim="cells", grid_info=grid)
 
     actual = index._repr_inline_(max_width)
 

--- a/xdggs/tests/test_h3.py
+++ b/xdggs/tests/test_h3.py
@@ -108,6 +108,15 @@ def test_init(cell_ids, dim, resolution):
     assert np.all(index._pd_index.index.values == cell_ids)
 
 
+@pytest.mark.parametrize("resolution", resolutions)
+def test_grid(resolution):
+    grid = h3.H3Info(resolution)
+
+    index = h3.H3Index([0], "cell_ids", grid)
+
+    assert index.grid is grid
+
+
 @pytest.mark.parametrize("variable", variables)
 @pytest.mark.parametrize("variable_name", variable_names)
 @pytest.mark.parametrize("options", [{}])

--- a/xdggs/tests/test_h3.py
+++ b/xdggs/tests/test_h3.py
@@ -114,7 +114,7 @@ def test_grid(resolution):
 
     index = h3.H3Index([0], "cell_ids", grid)
 
-    assert index.grid is grid
+    assert index.grid_info is grid
 
 
 @pytest.mark.parametrize("variable", variables)

--- a/xdggs/tests/test_h3.py
+++ b/xdggs/tests/test_h3.py
@@ -47,6 +47,52 @@ variable_combinations = [
 ]
 
 
+class TestH3Info:
+
+    @pytest.mark.parametrize(
+        ["resolution", "error"],
+        (
+            (0, None),
+            (1, None),
+            (-1, ValueError("resolution must be an integer between")),
+        ),
+    )
+    def test_init(self, resolution, error):
+        if error is not None:
+            with pytest.raises(type(error), match=str(error)):
+                h3.H3Info(resolution=resolution)
+            return
+
+        actual = h3.H3Info(resolution=resolution)
+
+        assert actual.resolution == resolution
+
+    @pytest.mark.parametrize(
+        ["mapping", "expected"],
+        (
+            ({"resolution": 0}, 0),
+            ({"resolution": 1}, 1),
+            ({"resolution": -1}, ValueError("resolution must be an integer between")),
+        ),
+    )
+    def test_from_dict(self, mapping, expected):
+        if isinstance(expected, Exception):
+            with pytest.raises(type(expected), match=str(expected)):
+                h3.H3Info.from_dict(mapping)
+            return
+
+        actual = h3.H3Info.from_dict(mapping)
+        assert actual.resolution == expected
+
+    def test_roundtrip(self):
+        mapping = {"grid_name": "h3", "resolution": 0}
+
+        grid = h3.H3Info.from_dict(mapping)
+        actual = grid.to_dict()
+
+        assert actual == mapping
+
+
 @pytest.mark.parametrize("resolution", resolutions)
 @pytest.mark.parametrize("dim", dims)
 @pytest.mark.parametrize("cell_ids", cell_ids)

--- a/xdggs/tests/test_h3.py
+++ b/xdggs/tests/test_h3.py
@@ -30,16 +30,16 @@ variable_names = ["cell_ids", "zonal_ids", "zone_ids"]
 
 variables = [
     xr.Variable(
-        dims[0], cell_ids[0], {"grid_type": "h3", "resolution": resolutions[0]}
+        dims[0], cell_ids[0], {"grid_name": "h3", "resolution": resolutions[0]}
     ),
     xr.Variable(
-        dims[1], cell_ids[0], {"grid_type": "h3", "resolution": resolutions[0]}
+        dims[1], cell_ids[0], {"grid_name": "h3", "resolution": resolutions[0]}
     ),
     xr.Variable(
-        dims[0], cell_ids[1], {"grid_type": "h3", "resolution": resolutions[1]}
+        dims[0], cell_ids[1], {"grid_name": "h3", "resolution": resolutions[1]}
     ),
     xr.Variable(
-        dims[1], cell_ids[2], {"grid_type": "h3", "resolution": resolutions[2]}
+        dims[1], cell_ids[2], {"grid_name": "h3", "resolution": resolutions[2]}
     ),
 ]
 variable_combinations = [

--- a/xdggs/tests/test_healpix.py
+++ b/xdggs/tests/test_healpix.py
@@ -47,6 +47,19 @@ class TestHealpixInfo:
         assert grid.nest == (True if indexing_scheme == "nested" else False)
 
     @given(resolutions, indexing_schemes, rotations)
+    def test_to_dict(self, resolution, indexing_scheme, rotation) -> None:
+        grid = healpix.HealpixInfo(
+            resolution=resolution, indexing_scheme=indexing_scheme, rotation=rotation
+        )
+        actual = grid.to_dict()
+
+        assert set(actual) == {"grid_name", "resolution", "indexing_scheme", "rotation"}
+        assert actual["grid_name"] == "healpix"
+        assert actual["resolution"] == resolution
+        assert actual["indexing_scheme"] == indexing_scheme
+        assert actual["rotation"] == rotation
+
+    @given(resolutions, indexing_schemes, rotations)
     def test_roundtrip(self, resolution, indexing_scheme, rotation):
         mapping = {
             "grid_name": "healpix",

--- a/xdggs/tests/test_healpix.py
+++ b/xdggs/tests/test_healpix.py
@@ -1,24 +1,43 @@
-import itertools
+# import itertools
 
+import hypothesis.extra.numpy as npst
 import hypothesis.strategies as st
 import numpy as np
 import pytest
-import xarray as xr
-from hypothesis import given
-from xarray.core.indexes import PandasIndex
 
+# import xarray as xr
+import xarray.testing.strategies as xrst
+from hypothesis import given
+
+# from xarray.core.indexes import PandasIndex
 from xdggs import healpix
 
 resolutions = st.integers(min_value=0, max_value=60)
 indexing_schemes = st.sampled_from(["nested", "ring", "unique"])
 
-lon_rotation = st.floats(min_value=-180.0, max_value=360.0)
-lat_rotation = st.floats(min_value=-90.0, max_value=90.0)
-rotations = st.tuples(lon_rotation, lat_rotation)
+
+def rotations():
+    lon_rotation = st.floats(min_value=-180.0, max_value=360.0)
+    lat_rotation = st.floats(min_value=-90.0, max_value=90.0)
+    return st.tuples(lon_rotation, lat_rotation)
+
+
+dims = xrst.names()
+
+
+def cell_ids(dtypes=npst.unsigned_integer_dtypes() | npst.integer_dtypes()):
+    shapes = npst.array_shapes(min_dims=1, max_dims=1)
+
+    return npst.arrays(
+        dtypes, shapes, elements={"min_value": 0}, unique=True, fill=st.nothing()
+    )
+
+
+options = st.just({})
 
 
 def grids(
-    resolutions=resolutions, indexing_schemes=indexing_schemes, rotations=rotations
+    resolutions=resolutions, indexing_schemes=indexing_schemes, rotations=rotations()
 ):
     return st.builds(
         healpix.HealpixInfo,
@@ -29,7 +48,7 @@ def grids(
 
 
 class TestHealpixInfo:
-    @given(resolutions, indexing_schemes, rotations)
+    @given(resolutions, indexing_schemes, rotations())
     def test_init(self, resolution, indexing_scheme, rotation) -> None:
         grid = healpix.HealpixInfo(
             resolution=resolution, indexing_scheme=indexing_scheme, rotation=rotation
@@ -57,7 +76,7 @@ class TestHealpixInfo:
 
         assert grid.nest == (True if indexing_scheme == "nested" else False)
 
-    @given(resolutions, indexing_schemes, rotations)
+    @given(resolutions, indexing_schemes, rotations())
     def test_to_dict(self, resolution, indexing_scheme, rotation) -> None:
         grid = healpix.HealpixInfo(
             resolution=resolution, indexing_scheme=indexing_scheme, rotation=rotation
@@ -70,7 +89,7 @@ class TestHealpixInfo:
         assert actual["indexing_scheme"] == indexing_scheme
         assert actual["rotation"] == rotation
 
-    @given(resolutions, indexing_schemes, rotations)
+    @given(resolutions, indexing_schemes, rotations())
     def test_roundtrip(self, resolution, indexing_scheme, rotation):
         mapping = {
             "grid_name": "healpix",
@@ -85,177 +104,200 @@ class TestHealpixInfo:
         assert roundtripped == mapping
 
 
-cell_ids = [
-    np.array([3]),
-    np.array([5, 11, 21]),
-    np.array([54, 70, 82, 91]),
-]
-cell_centers = [
-    np.array([[45.0, 14.47751219]]),
-    np.array([[61.875, 19.47122063], [33.75, 24.62431835], [84.375, 41.8103149]]),
-    np.array(
-        [
-            [56.25, 66.44353569],
-            [140.625, 19.47122063],
-            [151.875, 30.0],
-            [147.85714286, 48.14120779],
-        ]
-    ),
-]
+# cell_ids = [
+#     np.array([3]),
+#     np.array([5, 11, 21]),
+#     np.array([54, 70, 82, 91]),
+# ]
+# cell_centers = [
+#     np.array([[45.0, 14.47751219]]),
+#     np.array([[61.875, 19.47122063], [33.75, 24.62431835], [84.375, 41.8103149]]),
+#     np.array(
+#         [
+#             [56.25, 66.44353569],
+#             [140.625, 19.47122063],
+#             [151.875, 30.0],
+#             [147.85714286, 48.14120779],
+#         ]
+#     ),
+# ]
 
-pixel_orderings = ["nested", "ring"]
-resolutions = [1, 2, 8]
-rotation = [(0, 0)]
+# pixel_orderings = ["nested", "ring"]
+# resolutions = [1, 2, 8]
+# rotation = [(0, 0)]
 
-options = [{}]
-dims = ["cells", "zones"]
-variable_names = ["cell_ids", "zonal_ids", "zone_ids"]
-variables = [
-    xr.Variable(
-        dims[0],
-        cell_ids[0],
-        {
-            "grid_type": "healpix",
-            "nside": resolutions[0],
-            "nest": True,
-            "rotation": rotation[0],
-        },
-    ),
-    xr.Variable(
-        dims[1],
-        cell_ids[0],
-        {
-            "grid_type": "healpix",
-            "nside": resolutions[0],
-            "nest": False,
-            "rotation": rotation[0],
-        },
-    ),
-    xr.Variable(
-        dims[0],
-        cell_ids[1],
-        {
-            "grid_type": "healpix",
-            "nside": resolutions[1],
-            "nest": True,
-            "rotation": rotation[0],
-        },
-    ),
-    xr.Variable(
-        dims[1],
-        cell_ids[2],
-        {
-            "grid_type": "healpix",
-            "nside": resolutions[2],
-            "nest": False,
-            "rotation": rotation[0],
-        },
-    ),
-]
-variable_combinations = list(itertools.product(variables, repeat=2))
-
-
-@pytest.mark.parametrize("rotation", rotation)
-@pytest.mark.parametrize("pixel_ordering", pixel_orderings)
-@pytest.mark.parametrize("resolution", resolutions)
-@pytest.mark.parametrize("dim", dims)
-@pytest.mark.parametrize("cell_ids", cell_ids)
-def test_init(cell_ids, dim, resolution, pixel_ordering, rotation):
-    index = healpix.HealpixIndex(
-        cell_ids,
-        dim,
-        nside=resolution,
-        nest=pixel_ordering == "nested",
-        rot_latlon=rotation,
-    )
-
-    assert index._nside == resolution
-    assert index._dim == dim
-
-    assert index._pd_index.dim == dim
-    np.testing.assert_equal(index._pd_index.index.values, cell_ids)
+# options = [{}]
+# dims = ["cells", "zones"]
+# variable_names = ["cell_ids", "zonal_ids", "zone_ids"]
+# variables = [
+#     xr.Variable(
+#         dims[0],
+#         cell_ids[0],
+#         {
+#             "grid_type": "healpix",
+#             "nside": resolutions[0],
+#             "nest": True,
+#             "rotation": rotation[0],
+#         },
+#     ),
+#     xr.Variable(
+#         dims[1],
+#         cell_ids[0],
+#         {
+#             "grid_type": "healpix",
+#             "nside": resolutions[0],
+#             "nest": False,
+#             "rotation": rotation[0],
+#         },
+#     ),
+#     xr.Variable(
+#         dims[0],
+#         cell_ids[1],
+#         {
+#             "grid_type": "healpix",
+#             "nside": resolutions[1],
+#             "nest": True,
+#             "rotation": rotation[0],
+#         },
+#     ),
+#     xr.Variable(
+#         dims[1],
+#         cell_ids[2],
+#         {
+#             "grid_type": "healpix",
+#             "nside": resolutions[2],
+#             "nest": False,
+#             "rotation": rotation[0],
+#         },
+#     ),
+# ]
+# variable_combinations = list(itertools.product(variables, repeat=2))
 
 
-@pytest.mark.parametrize("options", options)
-@pytest.mark.parametrize("variable", variables)
-@pytest.mark.parametrize("variable_name", variable_names)
-def test_from_variables(variable_name, variable, options):
-    expected_resolution = variable.attrs["nside"]
-    expected_scheme = variable.attrs["nest"]
-    expected_rot = variable.attrs["rotation"]
-
-    variables = {variable_name: variable}
-
-    index = healpix.HealpixIndex.from_variables(variables, options=options)
-
-    assert index._nside == expected_resolution
-    assert index._nest == expected_scheme
-    assert index._rot_latlon == expected_rot
-
-    assert (index._dim,) == variable.dims
-    np.testing.assert_equal(index._pd_index.index.values, variable.data)
-
-
-@pytest.mark.parametrize(["old_variable", "new_variable"], variable_combinations)
-def test_replace(old_variable, new_variable):
-    index = healpix.HealpixIndex(
-        cell_ids=old_variable.data,
-        dim=old_variable.dims[0],
-        nside=old_variable.attrs["nside"],
-        nest=old_variable.attrs["nest"],
-        rot_latlon=old_variable.attrs["rotation"],
-    )
-
-    new_pandas_index = PandasIndex.from_variables(
-        {"cell_ids": new_variable}, options={}
-    )
-
-    new_index = index._replace(new_pandas_index)
-
-    assert new_index._nside == index._nside
-    assert new_index._nest == index._nest
-    assert new_index._rot_latlon == index._rot_latlon
-    assert new_index._dim == index._dim
-    assert new_index._pd_index == new_pandas_index
+# @pytest.mark.parametrize(["mapping", "expected"], (
+#     pytest.param(
+#         {"resolution": 10, "indexing_scheme": "nested", "rotation": (0.0, 0.0)},
+#         {"resolution": 10, "indexing_scheme": "nested", "rotation": (0.0, 0.0)},
+#         id="no_translation",
+#     ),
+#     pytest.param(
+#         {"resolution": 10, "indexing_scheme": "nested", "rotation": (0.0, 0.0), "grid_name": "healpix"},
+#         {"resolution": 10, "indexing_scheme": "nested", "rotation": (0.0, 0.0)},
+#         id="no_translation-grid_name",
+#     ),
+#     pytest.param(
+#         {"nside": 1024, "indexing_scheme": "nested", "rotation": (0.0, 0.0)},
+#         {"resolution": 10, "indexing_scheme": "nested", "rotation": (0.0, 0.0)},
+#         id="nside-alone",
+#     ),
+#     pytest.param(
+#         {"nside": 1024, "resolution": 10, "indexing_scheme": "nested", "rotation": (0.0, 0.0)},
+#         ExceptionGroup("received multiple values for parameters", [ValueError("Parameter resolution received multiple values: ['nside', 'resolution']")]),
+#         id="nside-duplicated",
+#     ),
+# ))
+# def test_healpix_info_from_dict(mapping, expected) -> None:
+#     if isinstance(expected, ExceptionGroup):
+#         with pytest.raises(type(expected), match=expected.args[0]) as actual:
+#             healpix.HealpixInfo.from_dict(mapping)
+#             assert_exceptions_equal(actual.value, expected)
+#         return
+#     actual = healpix.HealpixInfo.from_dict(mapping)
+#     assert actual == healpix.HealpixInfo(**expected)
 
 
-@pytest.mark.parametrize(
-    ["cell_ids", "cell_centers"], list(zip(cell_ids, cell_centers))
-)
-def test_cellid2latlon(cell_ids, cell_centers):
-    index = healpix.HealpixIndex(
-        cell_ids=[0], dim="cells", nside=8, nest=True, rot_latlon=(0, 0)
-    )
+class TestHealpixIndex:
+    @given(cell_ids(), dims, grids())
+    def test_init(self, cell_ids, dim, grid) -> None:
+        index = healpix.HealpixIndex(cell_ids, dim, grid)
 
-    actual = index._cellid2latlon(cell_ids)
-    expected = cell_centers
+        assert index._grid == grid
+        assert index._dim == dim
+        assert index._pd_index.dim == dim
 
-    np.testing.assert_allclose(actual, expected)
+        np.testing.assert_equal(index._pd_index.index.values, cell_ids)
 
 
-@pytest.mark.parametrize(
-    ["cell_centers", "cell_ids"], list(zip(cell_centers, cell_ids))
-)
-def test_latlon2cell_ids(cell_centers, cell_ids):
-    index = healpix.HealpixIndex(
-        cell_ids=[0], dim="cells", nside=8, nest=True, rot_latlon=(0, 0)
-    )
+# @pytest.mark.parametrize("options", options)
+# @pytest.mark.parametrize("variable", variables)
+# @pytest.mark.parametrize("variable_name", variable_names)
+# def test_from_variables(variable_name, variable, options) -> None:
+#     expected_resolution = variable.attrs["nside"]
+#     expected_scheme = variable.attrs["nest"]
+#     expected_rot = variable.attrs["rotation"]
 
-    actual = index._latlon2cellid(lon=cell_centers[:, 0], lat=cell_centers[:, 1])
-    expected = cell_ids
+#     variables = {variable_name: variable}
 
-    np.testing.assert_equal(actual, expected)
+#     index = healpix.HealpixIndex.from_variables(variables, options=options)
+
+#     assert index._nside == expected_resolution
+#     assert index._nest == expected_scheme
+#     assert index._rot_latlon == expected_rot
+
+#     assert (index._dim,) == variable.dims
+#     np.testing.assert_equal(index._pd_index.index.values, variable.data)
 
 
-@pytest.mark.parametrize("max_width", [20, 50, 80, 120])
-@pytest.mark.parametrize("resolution", resolutions)
-def test_repr_inline(resolution, max_width):
-    index = healpix.HealpixIndex(
-        cell_ids=[0], dim="cells", nside=resolution, nest=True, rot_latlon=(0, 0)
-    )
+# @pytest.mark.parametrize(["old_variable", "new_variable"], variable_combinations)
+# def test_replace(old_variable, new_variable) -> None:
+#     index = healpix.HealpixIndex(
+#         cell_ids=old_variable.data,
+#         dim=old_variable.dims[0],
+#         nside=old_variable.attrs["nside"],
+#         nest=old_variable.attrs["nest"],
+#         rot_latlon=old_variable.attrs["rotation"],
+#     )
 
-    actual = index._repr_inline_(max_width)
+#     new_pandas_index = PandasIndex.from_variables(
+#         {"cell_ids": new_variable}, options={}
+#     )
 
-    assert f"nside={resolution}" in actual
-    # ignore max_width for now
-    # assert len(actual) <= max_width
+#     new_index = index._replace(new_pandas_index)
+
+#     assert new_index._nside == index._nside
+#     assert new_index._nest == index._nest
+#     assert new_index._rot_latlon == index._rot_latlon
+#     assert new_index._dim == index._dim
+#     assert new_index._pd_index == new_pandas_index
+
+
+# @pytest.mark.parametrize(
+#     ["cell_ids", "cell_centers"], list(zip(cell_ids, cell_centers))
+# )
+# def test_cellid2latlon(cell_ids, cell_centers) -> None:
+#     index = healpix.HealpixIndex(
+#         cell_ids=[0], dim="cells", nside=8, nest=True, rot_latlon=(0, 0)
+#     )
+
+#     actual = index._cellid2latlon(cell_ids)
+#     expected = cell_centers
+
+#     np.testing.assert_allclose(actual, expected)
+
+
+# @pytest.mark.parametrize(
+#     ["cell_centers", "cell_ids"], list(zip(cell_centers, cell_ids))
+# )
+# def test_latlon2cell_ids(cell_centers, cell_ids) -> None:
+#     index = healpix.HealpixIndex(
+#         cell_ids=[0], dim="cells", nside=8, nest=True, rot_latlon=(0, 0)
+#     )
+
+#     actual = index._latlon2cellid(lon=cell_centers[:, 0], lat=cell_centers[:, 1])
+#     expected = cell_ids
+
+#     np.testing.assert_equal(actual, expected)
+
+
+# @pytest.mark.parametrize("max_width", [20, 50, 80, 120])
+# @pytest.mark.parametrize("resolution", resolutions)
+# def test_repr_inline(resolution, max_width) -> None:
+#     index = healpix.HealpixIndex(
+#         cell_ids=[0], dim="cells", resolution=resolution, scheme="nested", rot_latlon=(0, 0)
+#     )
+
+#     actual = index._repr_inline_(max_width)
+
+#     assert f"nside={resolution}" in actual
+#     # ignore max_width for now
+#     # assert len(actual) <= max_width

--- a/xdggs/tests/test_healpix.py
+++ b/xdggs/tests/test_healpix.py
@@ -12,6 +12,11 @@ from xarray.core.indexes import PandasIndex
 from xdggs import healpix
 from xdggs.tests import assert_exceptions_equal
 
+try:
+    ExceptionGroup
+except NameError:
+    from exceptiongroup import ExceptionGroup
+
 
 # namespace class
 class strategies:

--- a/xdggs/tests/test_healpix.py
+++ b/xdggs/tests/test_healpix.py
@@ -51,11 +51,6 @@ class strategies:
             "rotation": st.sampled_from(["rotation", "rot_latlon"]),
         }
 
-        def create_mapping(**params):
-            return st.builds(
-                lambda **x: x, **{p: strategies[p] for p in params.values()}
-            )
-
         return st.builds(lambda **x: list(x.values()), **names).flatmap(
             lambda params: st.builds(dict, **{p: strategies[p] for p in params})
         )

--- a/xdggs/tests/test_healpix.py
+++ b/xdggs/tests/test_healpix.py
@@ -1,97 +1,99 @@
-# import itertools
+import itertools
 
 import hypothesis.extra.numpy as npst
 import hypothesis.strategies as st
 import numpy as np
 import pytest
-
-# import xarray as xr
+import xarray as xr
 import xarray.testing.strategies as xrst
 from hypothesis import given
+from xarray.core.indexes import PandasIndex
 
-# from xarray.core.indexes import PandasIndex
 from xdggs import healpix
-
-invalid_resolutions = st.integers(max_value=-1) | st.integers(min_value=30)
-resolutions = st.integers(min_value=0, max_value=29)
-indexing_schemes = st.sampled_from(["nested", "ring", "unique"])
-invalid_indexing_schemes = st.text().filter(
-    lambda x: x not in ["nested", "ring", "unique"]
-)
+from xdggs.tests import assert_exceptions_equal
 
 
-def rotations():
-    lon_rotation = st.floats(min_value=-180.0, max_value=360.0)
-    lat_rotation = st.floats(min_value=-90.0, max_value=90.0)
-    return st.tuples(lon_rotation, lat_rotation)
-
-
-dims = xrst.names()
-
-
-def grid_mappings():
-    strategies = {
-        "resolution": resolutions,
-        "nside": resolutions.map(lambda n: 2**n),
-        "depth": resolutions,
-        "level": resolutions,
-        "order": resolutions,
-        "indexing_scheme": indexing_schemes,
-        "nest": st.booleans(),
-        "rotation": rotations(),
-        "rot_latlon": rotations().map(lambda x: x[::-1]),
-    }
-
-    names = {
-        "resolution": st.sampled_from(
-            ["resolution", "nside", "depth", "level", "order"]
-        ),
-        "indexing_scheme": st.sampled_from(["indexing_scheme", "nest"]),
-        "rotation": st.sampled_from(["rotation", "rot_latlon"]),
-    }
-
-    def create_mapping(**params):
-        return st.builds(lambda **x: x, **{p: strategies[p] for p in params.values()})
-
-    return st.builds(lambda **x: list(x.values()), **names).flatmap(
-        lambda params: st.builds(dict, **{p: strategies[p] for p in params})
+# namespace class
+class strategies:
+    invalid_resolutions = st.integers(max_value=-1) | st.integers(min_value=30)
+    resolutions = st.integers(min_value=0, max_value=29)
+    indexing_schemes = st.sampled_from(["nested", "ring", "unique"])
+    invalid_indexing_schemes = st.text().filter(
+        lambda x: x not in ["nested", "ring", "unique"]
     )
 
+    def rotations():
+        lon_rotation = st.floats(min_value=-180.0, max_value=360.0)
+        lat_rotation = st.floats(min_value=-90.0, max_value=90.0)
+        return st.tuples(lon_rotation, lat_rotation)
 
-def cell_ids(dtypes=None):
-    if dtypes is None:
-        # healpy can't deal with `uint32` or less (it segfaults occasionally)
-        dtypes = st.sampled_from(["uint64"])
-    shapes = npst.array_shapes(min_dims=1, max_dims=1)
+    dims = xrst.names()
 
-    return npst.arrays(
-        dtypes, shapes, elements={"min_value": 0}, unique=True, fill=st.nothing()
-    )
+    @classmethod
+    def grid_mappings(cls):
+        strategies = {
+            "resolution": cls.resolutions,
+            "nside": cls.resolutions.map(lambda n: 2**n),
+            "depth": cls.resolutions,
+            "level": cls.resolutions,
+            "order": cls.resolutions,
+            "indexing_scheme": cls.indexing_schemes,
+            "nest": st.booleans(),
+            "rotation": cls.rotations(),
+            "rot_latlon": cls.rotations().map(lambda x: x[::-1]),
+        }
 
+        names = {
+            "resolution": st.sampled_from(
+                ["resolution", "nside", "depth", "level", "order"]
+            ),
+            "indexing_scheme": st.sampled_from(["indexing_scheme", "nest"]),
+            "rotation": st.sampled_from(["rotation", "rot_latlon"]),
+        }
 
-options = st.just({})
+        def create_mapping(**params):
+            return st.builds(
+                lambda **x: x, **{p: strategies[p] for p in params.values()}
+            )
 
+        return st.builds(lambda **x: list(x.values()), **names).flatmap(
+            lambda params: st.builds(dict, **{p: strategies[p] for p in params})
+        )
 
-def grids(
-    resolutions=resolutions, indexing_schemes=indexing_schemes, rotations=rotations()
-):
-    return st.builds(
-        healpix.HealpixInfo,
-        resolution=resolutions,
-        indexing_scheme=indexing_schemes,
-        rotation=rotations,
-    )
+    def cell_ids(dtypes=None):
+        if dtypes is None:
+            # healpy can't deal with `uint32` or less (it segfaults occasionally)
+            dtypes = st.sampled_from(["uint64"])
+        shapes = npst.array_shapes(min_dims=1, max_dims=1)
+
+        return npst.arrays(
+            dtypes, shapes, elements={"min_value": 0}, unique=True, fill=st.nothing()
+        )
+
+    options = st.just({})
+
+    def grids(
+        resolutions=resolutions,
+        indexing_schemes=indexing_schemes,
+        rotations=rotations(),
+    ):
+        return st.builds(
+            healpix.HealpixInfo,
+            resolution=resolutions,
+            indexing_scheme=indexing_schemes,
+            rotation=rotations,
+        )
 
 
 class TestHealpixInfo:
-    @given(invalid_resolutions)
+    @given(strategies.invalid_resolutions)
     def test_init_invalid_resolutions(self, resolution):
         with pytest.raises(
             ValueError, match="resolution must be an integer in the range of"
         ):
             healpix.HealpixInfo(resolution=resolution)
 
-    @given(invalid_indexing_schemes)
+    @given(strategies.invalid_indexing_schemes)
     def test_init_invalid_indexing_scheme(self, indexing_scheme):
         with pytest.raises(ValueError, match="indexing scheme must be one of"):
             healpix.HealpixInfo(
@@ -99,7 +101,7 @@ class TestHealpixInfo:
                 indexing_scheme=indexing_scheme,
             )
 
-    @given(resolutions, indexing_schemes, rotations())
+    @given(strategies.resolutions, strategies.indexing_schemes, strategies.rotations())
     def test_init(self, resolution, indexing_scheme, rotation):
         grid = healpix.HealpixInfo(
             resolution=resolution, indexing_scheme=indexing_scheme, rotation=rotation
@@ -109,13 +111,13 @@ class TestHealpixInfo:
         assert grid.indexing_scheme == indexing_scheme
         assert grid.rotation == rotation
 
-    @given(resolutions)
+    @given(strategies.resolutions)
     def test_nside(self, resolution):
         grid = healpix.HealpixInfo(resolution=resolution)
 
         assert grid.nside == 2**resolution
 
-    @given(indexing_schemes)
+    @given(strategies.indexing_schemes)
     def test_nest(self, indexing_scheme):
         grid = healpix.HealpixInfo(resolution=1, indexing_scheme=indexing_scheme)
         if indexing_scheme not in {"nested", "ring"}:
@@ -127,11 +129,11 @@ class TestHealpixInfo:
 
         assert grid.nest == (True if indexing_scheme == "nested" else False)
 
-    @given(grid_mappings())
+    @given(strategies.grid_mappings())
     def test_from_dict(self, mapping) -> None:
         healpix.HealpixInfo.from_dict(mapping)
 
-    @given(resolutions, indexing_schemes, rotations())
+    @given(strategies.resolutions, strategies.indexing_schemes, strategies.rotations())
     def test_to_dict(self, resolution, indexing_scheme, rotation) -> None:
         grid = healpix.HealpixInfo(
             resolution=resolution, indexing_scheme=indexing_scheme, rotation=rotation
@@ -144,7 +146,7 @@ class TestHealpixInfo:
         assert actual["indexing_scheme"] == indexing_scheme
         assert actual["rotation"] == rotation
 
-    @given(resolutions, indexing_schemes, rotations())
+    @given(strategies.resolutions, strategies.indexing_schemes, strategies.rotations())
     def test_roundtrip(self, resolution, indexing_scheme, rotation):
         mapping = {
             "grid_name": "healpix",
@@ -159,110 +161,130 @@ class TestHealpixInfo:
         assert roundtripped == mapping
 
 
-# cell_ids = [
-#     np.array([3]),
-#     np.array([5, 11, 21]),
-#     np.array([54, 70, 82, 91]),
-# ]
-# cell_centers = [
-#     np.array([[45.0, 14.47751219]]),
-#     np.array([[61.875, 19.47122063], [33.75, 24.62431835], [84.375, 41.8103149]]),
-#     np.array(
-#         [
-#             [56.25, 66.44353569],
-#             [140.625, 19.47122063],
-#             [151.875, 30.0],
-#             [147.85714286, 48.14120779],
-#         ]
-#     ),
-# ]
+cell_ids = [
+    np.array([3]),
+    np.array([5, 11, 21]),
+    np.array([54, 70, 82, 91]),
+]
+cell_centers = [
+    np.array([[45.0, 14.47751219]]),
+    np.array([[61.875, 19.47122063], [33.75, 24.62431835], [84.375, 41.8103149]]),
+    np.array(
+        [
+            [56.25, 66.44353569],
+            [140.625, 19.47122063],
+            [151.875, 30.0],
+            [147.85714286, 48.14120779],
+        ]
+    ),
+]
 
-# pixel_orderings = ["nested", "ring"]
-# resolutions = [1, 2, 8]
-# rotation = [(0, 0)]
+pixel_orderings = ["nested", "ring"]
+resolutions = [1, 2, 8]
+rotation = [(0, 0)]
 
-# options = [{}]
-# dims = ["cells", "zones"]
-# variable_names = ["cell_ids", "zonal_ids", "zone_ids"]
-# variables = [
-#     xr.Variable(
-#         dims[0],
-#         cell_ids[0],
-#         {
-#             "grid_type": "healpix",
-#             "nside": resolutions[0],
-#             "nest": True,
-#             "rotation": rotation[0],
-#         },
-#     ),
-#     xr.Variable(
-#         dims[1],
-#         cell_ids[0],
-#         {
-#             "grid_type": "healpix",
-#             "nside": resolutions[0],
-#             "nest": False,
-#             "rotation": rotation[0],
-#         },
-#     ),
-#     xr.Variable(
-#         dims[0],
-#         cell_ids[1],
-#         {
-#             "grid_type": "healpix",
-#             "nside": resolutions[1],
-#             "nest": True,
-#             "rotation": rotation[0],
-#         },
-#     ),
-#     xr.Variable(
-#         dims[1],
-#         cell_ids[2],
-#         {
-#             "grid_type": "healpix",
-#             "nside": resolutions[2],
-#             "nest": False,
-#             "rotation": rotation[0],
-#         },
-#     ),
-# ]
-# variable_combinations = list(itertools.product(variables, repeat=2))
+options = [{}]
+dims = ["cells", "zones"]
+variable_names = ["cell_ids", "zonal_ids", "zone_ids"]
+variables = [
+    xr.Variable(
+        dims[0],
+        cell_ids[0],
+        {
+            "grid_type": "healpix",
+            "nside": resolutions[0],
+            "nest": True,
+            "rotation": rotation[0],
+        },
+    ),
+    xr.Variable(
+        dims[1],
+        cell_ids[0],
+        {
+            "grid_type": "healpix",
+            "nside": resolutions[0],
+            "nest": False,
+            "rotation": rotation[0],
+        },
+    ),
+    xr.Variable(
+        dims[0],
+        cell_ids[1],
+        {
+            "grid_type": "healpix",
+            "nside": resolutions[1],
+            "nest": True,
+            "rotation": rotation[0],
+        },
+    ),
+    xr.Variable(
+        dims[1],
+        cell_ids[2],
+        {
+            "grid_type": "healpix",
+            "nside": resolutions[2],
+            "nest": False,
+            "rotation": rotation[0],
+        },
+    ),
+]
+variable_combinations = list(itertools.product(variables, repeat=2))
 
 
-# @pytest.mark.parametrize(["mapping", "expected"], (
-#     pytest.param(
-#         {"resolution": 10, "indexing_scheme": "nested", "rotation": (0.0, 0.0)},
-#         {"resolution": 10, "indexing_scheme": "nested", "rotation": (0.0, 0.0)},
-#         id="no_translation",
-#     ),
-#     pytest.param(
-#         {"resolution": 10, "indexing_scheme": "nested", "rotation": (0.0, 0.0), "grid_name": "healpix"},
-#         {"resolution": 10, "indexing_scheme": "nested", "rotation": (0.0, 0.0)},
-#         id="no_translation-grid_name",
-#     ),
-#     pytest.param(
-#         {"nside": 1024, "indexing_scheme": "nested", "rotation": (0.0, 0.0)},
-#         {"resolution": 10, "indexing_scheme": "nested", "rotation": (0.0, 0.0)},
-#         id="nside-alone",
-#     ),
-#     pytest.param(
-#         {"nside": 1024, "resolution": 10, "indexing_scheme": "nested", "rotation": (0.0, 0.0)},
-#         ExceptionGroup("received multiple values for parameters", [ValueError("Parameter resolution received multiple values: ['nside', 'resolution']")]),
-#         id="nside-duplicated",
-#     ),
-# ))
-# def test_healpix_info_from_dict(mapping, expected) -> None:
-#     if isinstance(expected, ExceptionGroup):
-#         with pytest.raises(type(expected), match=expected.args[0]) as actual:
-#             healpix.HealpixInfo.from_dict(mapping)
-#             assert_exceptions_equal(actual.value, expected)
-#         return
-#     actual = healpix.HealpixInfo.from_dict(mapping)
-#     assert actual == healpix.HealpixInfo(**expected)
+@pytest.mark.parametrize(
+    ["mapping", "expected"],
+    (
+        pytest.param(
+            {"resolution": 10, "indexing_scheme": "nested", "rotation": (0.0, 0.0)},
+            {"resolution": 10, "indexing_scheme": "nested", "rotation": (0.0, 0.0)},
+            id="no_translation",
+        ),
+        pytest.param(
+            {
+                "resolution": 10,
+                "indexing_scheme": "nested",
+                "rotation": (0.0, 0.0),
+                "grid_name": "healpix",
+            },
+            {"resolution": 10, "indexing_scheme": "nested", "rotation": (0.0, 0.0)},
+            id="no_translation-grid_name",
+        ),
+        pytest.param(
+            {"nside": 1024, "indexing_scheme": "nested", "rotation": (0.0, 0.0)},
+            {"resolution": 10, "indexing_scheme": "nested", "rotation": (0.0, 0.0)},
+            id="nside-alone",
+        ),
+        pytest.param(
+            {
+                "nside": 1024,
+                "resolution": 10,
+                "indexing_scheme": "nested",
+                "rotation": (0.0, 0.0),
+            },
+            ExceptionGroup(
+                "received multiple values for parameters",
+                [
+                    ValueError(
+                        "Parameter resolution received multiple values: ['nside', 'resolution']"
+                    )
+                ],
+            ),
+            id="nside-duplicated",
+        ),
+    ),
+)
+def test_healpix_info_from_dict(mapping, expected) -> None:
+    if isinstance(expected, ExceptionGroup):
+        with pytest.raises(type(expected), match=expected.args[0]) as actual:
+            healpix.HealpixInfo.from_dict(mapping)
+        assert_exceptions_equal(actual.value, expected)
+        return
+    actual = healpix.HealpixInfo.from_dict(mapping)
+    assert actual == healpix.HealpixInfo(**expected)
 
 
 class TestHealpixIndex:
-    @given(cell_ids(), dims, grids())
+    @given(strategies.cell_ids(), strategies.dims, strategies.grids())
     def test_init(self, cell_ids, dim, grid) -> None:
         index = healpix.HealpixIndex(cell_ids, dim, grid)
 
@@ -272,7 +294,7 @@ class TestHealpixIndex:
 
         np.testing.assert_equal(index._pd_index.index.values, cell_ids)
 
-    @given(cell_ids(), dims, grids())
+    @given(strategies.cell_ids(), strategies.dims, strategies.grids())
     def test_cell_center_roundtrip(self, cell_ids, dim, grid) -> None:
         index = healpix.HealpixIndex(cell_ids, dim, grid)
 
@@ -283,86 +305,90 @@ class TestHealpixIndex:
         np.testing.assert_equal(actual, cell_ids)
 
 
-# @pytest.mark.parametrize("options", options)
-# @pytest.mark.parametrize("variable", variables)
-# @pytest.mark.parametrize("variable_name", variable_names)
-# def test_from_variables(variable_name, variable, options) -> None:
-#     expected_resolution = variable.attrs["nside"]
-#     expected_scheme = variable.attrs["nest"]
-#     expected_rot = variable.attrs["rotation"]
+@pytest.mark.parametrize("options", options)
+@pytest.mark.parametrize("variable", variables)
+@pytest.mark.parametrize("variable_name", variable_names)
+def test_from_variables(variable_name, variable, options) -> None:
+    expected_resolution = variable.attrs["nside"]
+    expected_scheme = variable.attrs["nest"]
+    expected_rot = variable.attrs["rotation"]
 
-#     variables = {variable_name: variable}
+    variables = {variable_name: variable}
 
-#     index = healpix.HealpixIndex.from_variables(variables, options=options)
+    index = healpix.HealpixIndex.from_variables(variables, options=options)
 
-#     assert index._nside == expected_resolution
-#     assert index._nest == expected_scheme
-#     assert index._rot_latlon == expected_rot
+    assert index._nside == expected_resolution
+    assert index._nest == expected_scheme
+    assert index._rot_latlon == expected_rot
 
-#     assert (index._dim,) == variable.dims
-#     np.testing.assert_equal(index._pd_index.index.values, variable.data)
-
-
-# @pytest.mark.parametrize(["old_variable", "new_variable"], variable_combinations)
-# def test_replace(old_variable, new_variable) -> None:
-#     index = healpix.HealpixIndex(
-#         cell_ids=old_variable.data,
-#         dim=old_variable.dims[0],
-#         nside=old_variable.attrs["nside"],
-#         nest=old_variable.attrs["nest"],
-#         rot_latlon=old_variable.attrs["rotation"],
-#     )
-
-#     new_pandas_index = PandasIndex.from_variables(
-#         {"cell_ids": new_variable}, options={}
-#     )
-
-#     new_index = index._replace(new_pandas_index)
-
-#     assert new_index._nside == index._nside
-#     assert new_index._nest == index._nest
-#     assert new_index._rot_latlon == index._rot_latlon
-#     assert new_index._dim == index._dim
-#     assert new_index._pd_index == new_pandas_index
+    assert (index._dim,) == variable.dims
+    np.testing.assert_equal(index._pd_index.index.values, variable.data)
 
 
-# @pytest.mark.parametrize(
-#     ["cell_ids", "cell_centers"], list(zip(cell_ids, cell_centers))
-# )
-# def test_cellid2latlon(cell_ids, cell_centers) -> None:
-#     index = healpix.HealpixIndex(
-#         cell_ids=[0], dim="cells", nside=8, nest=True, rot_latlon=(0, 0)
-#     )
+@pytest.mark.parametrize(["old_variable", "new_variable"], variable_combinations)
+def test_replace(old_variable, new_variable) -> None:
+    index = healpix.HealpixIndex(
+        cell_ids=old_variable.data,
+        dim=old_variable.dims[0],
+        nside=old_variable.attrs["nside"],
+        nest=old_variable.attrs["nest"],
+        rot_latlon=old_variable.attrs["rotation"],
+    )
 
-#     actual = index._cellid2latlon(cell_ids)
-#     expected = cell_centers
+    new_pandas_index = PandasIndex.from_variables(
+        {"cell_ids": new_variable}, options={}
+    )
 
-#     np.testing.assert_allclose(actual, expected)
+    new_index = index._replace(new_pandas_index)
 
-
-# @pytest.mark.parametrize(
-#     ["cell_centers", "cell_ids"], list(zip(cell_centers, cell_ids))
-# )
-# def test_latlon2cell_ids(cell_centers, cell_ids) -> None:
-#     index = healpix.HealpixIndex(
-#         cell_ids=[0], dim="cells", nside=8, nest=True, rot_latlon=(0, 0)
-#     )
-
-#     actual = index._latlon2cellid(lon=cell_centers[:, 0], lat=cell_centers[:, 1])
-#     expected = cell_ids
-
-#     np.testing.assert_equal(actual, expected)
+    assert new_index._nside == index._nside
+    assert new_index._nest == index._nest
+    assert new_index._rot_latlon == index._rot_latlon
+    assert new_index._dim == index._dim
+    assert new_index._pd_index == new_pandas_index
 
 
-# @pytest.mark.parametrize("max_width", [20, 50, 80, 120])
-# @pytest.mark.parametrize("resolution", resolutions)
-# def test_repr_inline(resolution, max_width) -> None:
-#     index = healpix.HealpixIndex(
-#         cell_ids=[0], dim="cells", resolution=resolution, scheme="nested", rot_latlon=(0, 0)
-#     )
+@pytest.mark.parametrize(
+    ["cell_ids", "cell_centers"], list(zip(cell_ids, cell_centers))
+)
+def test_cellid2latlon(cell_ids, cell_centers) -> None:
+    index = healpix.HealpixIndex(
+        cell_ids=[0], dim="cells", nside=8, nest=True, rot_latlon=(0, 0)
+    )
 
-#     actual = index._repr_inline_(max_width)
+    actual = index._cellid2latlon(cell_ids)
+    expected = cell_centers
 
-#     assert f"nside={resolution}" in actual
-#     # ignore max_width for now
-#     # assert len(actual) <= max_width
+    np.testing.assert_allclose(actual, expected)
+
+
+@pytest.mark.parametrize(
+    ["cell_centers", "cell_ids"], list(zip(cell_centers, cell_ids))
+)
+def test_latlon2cell_ids(cell_centers, cell_ids) -> None:
+    index = healpix.HealpixIndex(
+        cell_ids=[0], dim="cells", nside=8, nest=True, rot_latlon=(0, 0)
+    )
+
+    actual = index._latlon2cellid(lon=cell_centers[:, 0], lat=cell_centers[:, 1])
+    expected = cell_ids
+
+    np.testing.assert_equal(actual, expected)
+
+
+@pytest.mark.parametrize("max_width", [20, 50, 80, 120])
+@pytest.mark.parametrize("resolution", resolutions)
+def test_repr_inline(resolution, max_width) -> None:
+    index = healpix.HealpixIndex(
+        cell_ids=[0],
+        dim="cells",
+        resolution=resolution,
+        scheme="nested",
+        rot_latlon=(0, 0),
+    )
+
+    actual = index._repr_inline_(max_width)
+
+    assert f"nside={resolution}" in actual
+    # ignore max_width for now
+    # assert len(actual) <= max_width

--- a/xdggs/tests/test_healpix.py
+++ b/xdggs/tests/test_healpix.py
@@ -17,6 +17,17 @@ lat_rotation = st.floats(min_value=-90.0, max_value=90.0)
 rotations = st.tuples(lon_rotation, lat_rotation)
 
 
+def grids(
+    resolutions=resolutions, indexing_schemes=indexing_schemes, rotations=rotations
+):
+    return st.builds(
+        healpix.HealpixInfo,
+        resolution=resolutions,
+        indexing_scheme=indexing_schemes,
+        rotation=rotations,
+    )
+
+
 class TestHealpixInfo:
     @given(resolutions, indexing_schemes, rotations)
     def test_init(self, resolution, indexing_scheme, rotation) -> None:

--- a/xdggs/tests/test_healpix.py
+++ b/xdggs/tests/test_healpix.py
@@ -283,7 +283,7 @@ variable_combinations = list(itertools.product(variables, repeat=2))
                 "received multiple values for parameters",
                 [
                     ValueError(
-                        "Parameter indexing_scheme received multiple values: ['nest', 'indexing_scheme']"
+                        "Parameter indexing_scheme received multiple values: ['indexing_scheme', 'nest']"
                     ),
                 ],
             ),
@@ -301,10 +301,10 @@ variable_combinations = list(itertools.product(variables, repeat=2))
                 "received multiple values for parameters",
                 [
                     ValueError(
-                        "Parameter resolution received multiple values: ['nside', 'resolution']"
+                        "Parameter indexing_scheme received multiple values: ['indexing_scheme', 'nest']"
                     ),
                     ValueError(
-                        "Parameter indexing_scheme received multiple values: ['nest', 'indexing_scheme']"
+                        "Parameter resolution received multiple values: ['nside', 'resolution']"
                     ),
                 ],
             ),

--- a/xdggs/tests/test_healpix.py
+++ b/xdggs/tests/test_healpix.py
@@ -190,12 +190,7 @@ class TestHealpixInfo:
         assert roundtripped == mapping
 
 
-pixel_orderings = ["nested", "ring"]
-resolutions = [0, 1, 3]
-rotation = [(0, 0)]
-
 options = [{}]
-dims = ["cells", "zones"]
 variable_names = ["cell_ids", "zonal_ids", "zone_ids"]
 variables = [
     xr.Variable(
@@ -461,7 +456,7 @@ def test_latlon2cell_ids(cell_centers, resolution, indexing_scheme, expected) ->
 
 
 @pytest.mark.parametrize("max_width", [20, 50, 80, 120])
-@pytest.mark.parametrize("resolution", resolutions)
+@pytest.mark.parametrize("resolution", [0, 1, 3])
 def test_repr_inline(resolution, max_width) -> None:
     grid_info = healpix.HealpixInfo(
         resolution=resolution, indexing_scheme="nested", rotation=(0, 0)

--- a/xdggs/tests/test_healpix.py
+++ b/xdggs/tests/test_healpix.py
@@ -353,6 +353,12 @@ class TestHealpixIndex:
 
         np.testing.assert_equal(roundtripped, cell_ids)
 
+    @given(strategies.grids())
+    def test_grid(self, grid):
+        index = healpix.HealpixIndex([0], dim="cells", grid_info=grid)
+
+        assert index.grid is grid
+
 
 @pytest.mark.parametrize("options", options)
 @pytest.mark.parametrize("variable", variables)

--- a/xdggs/tests/test_healpix.py
+++ b/xdggs/tests/test_healpix.py
@@ -357,7 +357,7 @@ class TestHealpixIndex:
     def test_grid(self, grid):
         index = healpix.HealpixIndex([0], dim="cells", grid_info=grid)
 
-        assert index.grid is grid
+        assert index.grid_info is grid
 
 
 @pytest.mark.parametrize("options", options)

--- a/xdggs/tests/test_healpix.py
+++ b/xdggs/tests/test_healpix.py
@@ -127,7 +127,9 @@ class TestHealpixInfo:
                 grid.nest
             return
 
-        assert grid.nest == (True if indexing_scheme == "nested" else False)
+        expected = indexing_scheme == "nested"
+
+        assert grid.nest == expected
 
     @given(strategies.grid_mappings())
     def test_from_dict(self, mapping) -> None:

--- a/xdggs/tests/test_healpix.py
+++ b/xdggs/tests/test_healpix.py
@@ -29,6 +29,35 @@ def rotations():
 dims = xrst.names()
 
 
+def grid_mappings():
+    strategies = {
+        "resolution": resolutions,
+        "nside": st.integers(min_value=0),
+        "depth": resolutions,
+        "level": resolutions,
+        "order": resolutions,
+        "indexing_scheme": indexing_schemes,
+        "nest": st.booleans(),
+        "rotation": rotations(),
+        "rot_latlon": rotations().map(lambda x: x[::-1]),
+    }
+
+    names = {
+        "resolution": st.sampled_from(
+            ["resolution", "nside", "depth", "level", "order"]
+        ),
+        "indexing_scheme": st.sampled_from(["indexing_scheme", "nest"]),
+        "rotation": st.sampled_from(["rotation", "rot_latlon"]),
+    }
+
+    def create_mapping(**params):
+        return st.builds(lambda **x: x, **{p: strategies[p] for p in params.values()})
+
+    return st.builds(lambda **x: list(x.values()), **names).flatmap(
+        lambda params: st.builds(dict, **{p: strategies[p] for p in params})
+    )
+
+
 def cell_ids(dtypes=npst.unsigned_integer_dtypes() | npst.integer_dtypes()):
     shapes = npst.array_shapes(min_dims=1, max_dims=1)
 

--- a/xdggs/tests/test_healpix.py
+++ b/xdggs/tests/test_healpix.py
@@ -17,7 +17,7 @@ from xdggs.tests import assert_exceptions_equal
 class strategies:
     invalid_resolutions = st.integers(max_value=-1) | st.integers(min_value=30)
     resolutions = st.integers(min_value=0, max_value=29)
-    indexing_schemes = st.sampled_from(["nested", "ring", "unique"])
+    indexing_schemes = st.sampled_from(["nested", "ring"])
     invalid_indexing_schemes = st.text().filter(
         lambda x: x not in ["nested", "ring", "unique"]
     )
@@ -293,16 +293,6 @@ class TestHealpixIndex:
         assert index._pd_index.dim == dim
 
         np.testing.assert_equal(index._pd_index.index.values, cell_ids)
-
-    @given(strategies.cell_ids(), strategies.dims, strategies.grids())
-    def test_cell_center_roundtrip(self, cell_ids, dim, grid) -> None:
-        index = healpix.HealpixIndex(cell_ids, dim, grid)
-
-        lon, lat = index._cellid2latlon(cell_ids)
-
-        actual = index._latlon2cellid(lat, lon)
-
-        np.testing.assert_equal(actual, cell_ids)
 
 
 @pytest.mark.parametrize("options", options)

--- a/xdggs/tests/test_healpix.py
+++ b/xdggs/tests/test_healpix.py
@@ -349,7 +349,7 @@ class TestHealpixIndex:
 
         centers = index._cellid2latlon(cell_ids)
 
-        roundtripped = index._latlon2cellid(lat=centers[:, 1], lon=centers[:, 0])
+        roundtripped = index._latlon2cellid(lat=centers[1], lon=centers[0])
 
         np.testing.assert_equal(roundtripped, cell_ids)
 
@@ -408,14 +408,15 @@ def test_replace(old_variable, new_variable) -> None:
             np.array([3]),
             1,
             "ring",
-            np.array([[315.0, 66.44353569089877]]),
+            (np.array([315.0]), np.array([66.44353569089877])),
         ),
         pytest.param(
             np.array([5, 11, 21]),
             3,
             "nested",
-            np.array(
-                [[61.875, 19.47122063], [33.75, 24.62431835], [84.375, 41.8103149]]
+            (
+                np.array([61.875, 33.75, 84.375]),
+                np.array([19.47122063, 24.62431835, 41.8103149]),
             ),
         ),
     ),
@@ -426,9 +427,10 @@ def test_cellid2latlon(cell_ids, resolution, indexing_scheme, expected) -> None:
     )
     index = healpix.HealpixIndex(cell_ids=[0], dim="cells", grid_info=grid_info)
 
-    actual = index._cellid2latlon(cell_ids)
+    actual_lon, actual_lat = index._cellid2latlon(cell_ids)
 
-    np.testing.assert_allclose(actual, expected)
+    np.testing.assert_allclose(actual_lon, expected[0])
+    np.testing.assert_allclose(actual_lat, expected[1])
 
 
 @pytest.mark.parametrize(

--- a/xdggs/tests/test_healpix.py
+++ b/xdggs/tests/test_healpix.py
@@ -58,7 +58,10 @@ def grid_mappings():
     )
 
 
-def cell_ids(dtypes=npst.unsigned_integer_dtypes() | npst.integer_dtypes()):
+def cell_ids(dtypes=None):
+    if dtypes is None:
+        # healpy can't deal with `uint32` or less (it segfaults occasionally)
+        dtypes = st.sampled_from(["uint64"])
     shapes = npst.array_shapes(min_dims=1, max_dims=1)
 
     return npst.arrays(

--- a/xdggs/tests/test_healpix.py
+++ b/xdggs/tests/test_healpix.py
@@ -269,6 +269,16 @@ class TestHealpixIndex:
 
         np.testing.assert_equal(index._pd_index.index.values, cell_ids)
 
+    @given(cell_ids(), dims, grids())
+    def test_cell_center_roundtrip(self, cell_ids, dim, grid) -> None:
+        index = healpix.HealpixIndex(cell_ids, dim, grid)
+
+        lon, lat = index._cellid2latlon(cell_ids)
+
+        actual = index._latlon2cellid(lat, lon)
+
+        np.testing.assert_equal(actual, cell_ids)
+
 
 # @pytest.mark.parametrize("options", options)
 # @pytest.mark.parametrize("variable", variables)

--- a/xdggs/tests/test_healpix.py
+++ b/xdggs/tests/test_healpix.py
@@ -180,7 +180,7 @@ cell_centers = [
 ]
 
 pixel_orderings = ["nested", "ring"]
-resolutions = [1, 2, 8]
+resolutions = [0, 1, 3]
 rotation = [(0, 0)]
 
 options = [{}]
@@ -192,8 +192,8 @@ variables = [
         cell_ids[0],
         {
             "grid_name": "healpix",
-            "nside": resolutions[0],
-            "nest": True,
+            "resolution": resolutions[0],
+            "indexing_scheme": "nested",
             "rotation": rotation[0],
         },
     ),
@@ -202,8 +202,8 @@ variables = [
         cell_ids[0],
         {
             "grid_name": "healpix",
-            "nside": resolutions[0],
-            "nest": False,
+            "resolution": resolutions[0],
+            "indexing_scheme": "ring",
             "rotation": rotation[0],
         },
     ),
@@ -212,8 +212,8 @@ variables = [
         cell_ids[1],
         {
             "grid_name": "healpix",
-            "nside": resolutions[1],
-            "nest": True,
+            "resolution": resolutions[1],
+            "indexing_scheme": "nested",
             "rotation": rotation[0],
         },
     ),
@@ -222,8 +222,8 @@ variables = [
         cell_ids[2],
         {
             "grid_name": "healpix",
-            "nside": resolutions[2],
-            "nest": False,
+            "resolution": resolutions[2],
+            "indexing_scheme": "nested",
             "rotation": rotation[0],
         },
     ),
@@ -309,17 +309,17 @@ class TestHealpixIndex:
 @pytest.mark.parametrize("variable", variables)
 @pytest.mark.parametrize("variable_name", variable_names)
 def test_from_variables(variable_name, variable, options) -> None:
-    expected_resolution = variable.attrs["nside"]
-    expected_scheme = variable.attrs["nest"]
+    expected_resolution = variable.attrs["resolution"]
+    expected_scheme = variable.attrs["indexing_scheme"]
     expected_rot = variable.attrs["rotation"]
 
     variables = {variable_name: variable}
 
     index = healpix.HealpixIndex.from_variables(variables, options=options)
 
-    assert index._grid.nside == expected_resolution
-    assert index._grid.nest == expected_scheme
-    assert index._grid.rot_latlon == expected_rot
+    assert index._grid.resolution == expected_resolution
+    assert index._grid.indexing_scheme == expected_scheme
+    assert index._grid.rotation == expected_rot
 
     assert (index._dim,) == variable.dims
     np.testing.assert_equal(index._pd_index.index.values, variable.data)

--- a/xdggs/tests/test_healpix.py
+++ b/xdggs/tests/test_healpix.py
@@ -32,7 +32,7 @@ dims = xrst.names()
 def grid_mappings():
     strategies = {
         "resolution": resolutions,
-        "nside": st.integers(min_value=0),
+        "nside": resolutions.map(lambda n: 2**n),
         "depth": resolutions,
         "level": resolutions,
         "order": resolutions,

--- a/xdggs/tests/test_healpix.py
+++ b/xdggs/tests/test_healpix.py
@@ -124,6 +124,10 @@ class TestHealpixInfo:
 
         assert grid.nest == (True if indexing_scheme == "nested" else False)
 
+    @given(grid_mappings())
+    def test_from_dict(self, mapping) -> None:
+        healpix.HealpixInfo.from_dict(mapping)
+
     @given(resolutions, indexing_schemes, rotations())
     def test_to_dict(self, resolution, indexing_scheme, rotation) -> None:
         grid = healpix.HealpixInfo(

--- a/xdggs/tests/test_healpix.py
+++ b/xdggs/tests/test_healpix.py
@@ -60,14 +60,18 @@ class strategies:
             lambda params: st.builds(dict, **{p: strategies[p] for p in params})
         )
 
-    def cell_ids(dtypes=None):
+    def cell_ids(max_value=None, dtypes=None):
         if dtypes is None:
             # healpy can't deal with `uint32` or less (it segfaults occasionally)
             dtypes = st.sampled_from(["uint64"])
         shapes = npst.array_shapes(min_dims=1, max_dims=1)
 
         return npst.arrays(
-            dtypes, shapes, elements={"min_value": 0}, unique=True, fill=st.nothing()
+            dtypes,
+            shapes,
+            elements={"min_value": 0, "max_value": max_value},
+            unique=True,
+            fill=st.nothing(),
         )
 
     options = st.just({})

--- a/xdggs/tests/test_healpix.py
+++ b/xdggs/tests/test_healpix.py
@@ -17,7 +17,7 @@ from xdggs.tests import assert_exceptions_equal
 class strategies:
     invalid_resolutions = st.integers(max_value=-1) | st.integers(min_value=30)
     resolutions = st.integers(min_value=0, max_value=29)
-    indexing_schemes = st.sampled_from(["nested", "ring"])
+    indexing_schemes = st.sampled_from(["nested", "ring", "unique"])
     invalid_indexing_schemes = st.text().filter(
         lambda x: x not in ["nested", "ring", "unique"]
     )

--- a/xdggs/tests/test_healpix.py
+++ b/xdggs/tests/test_healpix.py
@@ -14,7 +14,7 @@ from xdggs.tests import assert_exceptions_equal
 
 try:
     ExceptionGroup
-except NameError:
+except NameError:  # pragma: no cover
     from exceptiongroup import ExceptionGroup
 
 

--- a/xdggs/tests/test_index.py
+++ b/xdggs/tests/test_index.py
@@ -13,16 +13,16 @@ def dggs_example():
 
 def test_create_index(dggs_example):
     # TODO: improve unknown index message
-    with pytest.raises(KeyError, match="test"):
+    with pytest.raises(ValueError, match="test"):
         dggs_example.set_xindex("cell_ids", index.DGGSIndex)
 
 
 def test_decode(dggs_example):
     # TODO: improve unknown index message
-    with pytest.raises(KeyError, match="test"):
+    with pytest.raises(ValueError, match="test"):
         dggs_example.pipe(index.decode)
 
 
 def test_decode_indexed(dggs_example):
-    with pytest.raises(KeyError, match="test"):
+    with pytest.raises(ValueError, match="test"):
         dggs_example.set_xindex("cell_ids").pipe(index.decode)


### PR DESCRIPTION
- [x] towards #35, closes #34

Before I do too much work on this, here's a draft of what I would imagine this concept to look like.

The objects are tentatively named `*Info`, once we have a better name I'm open to changing to that. Note that I decided against a common base class, because the only shared methods are `from_dict` and `to_dict`. For typing (once we really have that), I imagine we'd use a protocol instead. However, if we find good reason to go the other way I'd be open for that as well.