### PR TITLE
decoder function

### DIFF
--- a/xdggs/index.py
+++ b/xdggs/index.py
@@ -8,7 +8,7 @@ from xarray.indexes import Index, PandasIndex
 from xdggs.utils import GRID_REGISTRY, _extract_cell_id_variable
 
 
-def decode_dggs(ds):
+def decode(ds):
     variable_name = "cell_ids"
 
     return ds.set_xindex(variable_name, DGGSIndex)

--- a/xdggs/index.py
+++ b/xdggs/index.py
@@ -8,6 +8,12 @@ from xarray.indexes import Index, PandasIndex
 from xdggs.utils import GRID_REGISTRY, _extract_cell_id_variable
 
 
+def decode_dggs(ds):
+    variable_name = "cell_ids"
+
+    return ds.set_xindex(variable_name, DGGSIndex)
+
+
 class DGGSIndex(Index):
     _dim: str
     _pd_index: PandasIndex


### PR DESCRIPTION
The current way of creating the DGGS index is pretty verbose:

``` python
ds.set_xindex("cell_ids", xdggs.DGGSIndex)
```

In this PR, I'm proposing to add a top-level function that hides that detail. You'd call it like this:

```python
ds.pipe(xdggs.decode)
```

Should we ever get the custom decoder machinery in `xarray`, we could have it call `xdggs.decode`.

We could alternatively use `ds.dggs.decode()`, but so far all methods in the `dggs` namespace require the index to exist, and this would be an exception to that.

At the moment the variable name is hard-coded to `cell_ids`, but we could just as well use `filter_by_attrs` instead.

This would fix #13 without being too specific (as `create_index` would be) nor having somewhat confusing names (`from_x`, `to_x`), with the downside that we'd be reusing the term `decode` with a slightly different meaning: so far `decode` would take attributes, modify the data and move the attributes to `.encoding` (and `encode` does the inverse). By "decoding" a dggs index we're not actually invalidating the attributes, which is why this does not fit exactly (but I think it is close enough).