### PR TITLE
expose and test the `decode` function

### DIFF
--- a/examples/example_h3.ipynb
+++ b/examples/example_h3.ipynb
@@ -10,7 +10,9 @@
     "import numpy as np\n",
     "import xarray as xr\n",
     "\n",
-    "import xdggs"
+    "import xdggs\n",
+    "\n",
+    "xr.set_options(keep_attrs=True, display_expand_attrs=False, display_expand_indexes=True)"
    ]
   },
   {

--- a/examples/example_h3.ipynb
+++ b/examples/example_h3.ipynb
@@ -22,8 +22,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ds = xr.open_dataset(\"data/h3_example.nc\")\n",
-    "ds = ds"
+    "ds = xr.open_dataset(\"data/h3.nc\", engine=\"netcdf4\")\n",
+    "ds"
    ]
   },
   {

--- a/examples/example_h3.ipynb
+++ b/examples/example_h3.ipynb
@@ -33,8 +33,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ds_idx = ds.drop_indexes(\"cell\").set_xindex(\"cell\", xdggs.DGGSIndex)\n",
-    "\n",
+    "ds_idx = ds.pipe(xdggs.decode)\n",
     "ds_idx"
    ]
   },

--- a/xdggs/__init__.py
+++ b/xdggs/__init__.py
@@ -3,7 +3,7 @@ from importlib.metadata import PackageNotFoundError, version
 from xdggs.accessor import DGGSAccessor  # noqa
 from xdggs.h3 import H3Index
 from xdggs.healpix import HealpixIndex
-from xdggs.index import DGGSIndex
+from xdggs.index import DGGSIndex, decode
 
 try:
     __version__ = version("xdggs")
@@ -11,4 +11,4 @@ except PackageNotFoundError:  # noqa
     # package is not installed
     __version__ = "9999"
 
-__all__ = ["__version__", "DGGSIndex", "H3Index", "HealpixIndex"]
+__all__ = ["__version__", "DGGSIndex", "H3Index", "HealpixIndex", "decode"]

--- a/xdggs/index.py
+++ b/xdggs/index.py
@@ -11,7 +11,9 @@ from xdggs.utils import GRID_REGISTRY, _extract_cell_id_variable
 def decode(ds):
     variable_name = "cell_ids"
 
-    return ds.set_xindex(variable_name, DGGSIndex)
+    return ds.drop_indexes(variable_name, errors="ignore").set_xindex(
+        variable_name, DGGSIndex
+    )
 
 
 class DGGSIndex(Index):

--- a/xdggs/tests/test_index.py
+++ b/xdggs/tests/test_index.py
@@ -1,0 +1,28 @@
+import pytest
+import xarray as xr
+
+from xdggs import index
+
+
+@pytest.fixture
+def dggs_example():
+    return xr.Dataset(
+        coords={"cell_ids": ("cells", [0, 1], {"grid_name": "test", "resolution": 2})}
+    )
+
+
+def test_create_index(dggs_example):
+    # TODO: improve unknown index message
+    with pytest.raises(KeyError, match="test"):
+        dggs_example.set_xindex("cell_ids", index.DGGSIndex)
+
+
+def test_decode(dggs_example):
+    # TODO: improve unknown index message
+    with pytest.raises(KeyError, match="test"):
+        dggs_example.pipe(index.decode)
+
+
+def test_decode_indexed(dggs_example):
+    with pytest.raises(KeyError, match="test"):
+        dggs_example.set_xindex("cell_ids").pipe(index.decode)


### PR DESCRIPTION
- [x] follow-up to #47

I might have merged #47 too quickly, that needs a bit more work. First, it should be exposed at the top-level as `xdggs.decode`. Second, it should replace existing indexes on the `cell_ids` variable (supporting non-pandas indexes is something we can ignore for now). And finally, we need some tests.