### PR TITLE
disable the upstream-dev CI

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,8 +6,8 @@ on:
   pull_request:
     branches: ["main"]
     types: [opened, reopened, synchronize, labeled]
-  schedule:
-    - cron: "0 0 * * *" # Daily “At 00:00” UTC
+  # schedule:
+  #   - cron: "0 0 * * *" # Daily “At 00:00” UTC
   workflow_dispatch: # allows you to trigger the workflow run manually
 
 concurrency:


### PR DESCRIPTION
The upstream-dev CI has been consistently failing over the past few months because of dependency issues in `healpy`. I don't think I will be able to fix that until `healpy` releases its newest version (see #51 for my most recent attempt), and since `xdggs` currently depends on `healpy` that means we can only disable the scheduled CI for now.