### PR TITLE
`pre-commit` hook maintenance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,6 +138,9 @@ venv.bak/
 # mkdocs documentation
 /site
 
+# code formatter cache
+.prettier_cache/
+
 # mypy
 .mypy_cache/
 .dmypy.json

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,11 +21,6 @@ repos:
     rev: 24.3.0
     hooks:
       - id: black-jupyter
-  - repo: https://github.com/MarcoGorelli/absolufy-imports
-    rev: v0.3.1
-    hooks:
-      - id: absolufy-imports
-        files: ^xdggs/
   - repo: https://github.com/kynan/nbstripout
     rev: 0.7.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,7 @@ repos:
     rev: v4.0.0-alpha.8
     hooks:
       - id: prettier
+        args: [--cache-location=.prettier_cache/cache]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.3.5
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,9 @@ exclude = [
     "dist",
     "__pycache__",
 ]
+line-length = 100
+
+[tool.ruff.lint]
 # E402: module level import not at top of file
 # E501: line too long - let black worry about that
 # E731: do not assign a lambda expression, use a def
@@ -71,12 +74,9 @@ select = [
     # Pyupgrade
     "UP",
 ]
-line-length = 100
-
-[tool.ruff.lint]
 fixable = ["I"]
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 known-first-party = ["xdggs"]
 known-third-party=[
     "xarray",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,16 +65,17 @@ ignore = [
     "E731",
 ]
 select = [
-    # Pyflakes
-    "F",
-    # Pycodestyle
-    "E",
-    # isort
-    "I",
-    # Pyupgrade
-    "UP",
+    "F",  # Pyflakes
+    "E",  # Pycodestyle
+    "I",  # isort
+    "UP", # Pyupgrade
+    "TID", # flake8-tidy-imports
+    "W",
 ]
-fixable = ["I"]
+extend-safe-fixes = [
+    "TID252", # absolute imports
+]
+fixable = ["I", "TID252"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["xdggs"]


### PR DESCRIPTION
This includes:
- telling `prettier` to put its cache files into a separate (ignored, hidden) directory
- updating the configuration of `ruff` (so it doesn't complain anymore)
- replace the archived `absolufy-imports`