### PR TITLE
testing utils for exception groups

### DIFF
--- a/xdggs/tests/matchers.py
+++ b/xdggs/tests/matchers.py
@@ -1,5 +1,4 @@
 import enum
-import re
 from dataclasses import dataclass, field
 
 try:
@@ -54,11 +53,6 @@ class Match:
             submatchers=children,
             match=mapping.get("match", None),
         )
-
-    def assert_match(self, exc):
-        assert type(exc) is type(self.exc)  # noqa: E721
-
-        assert re.search(str(exc), self.match), "message does not match"
 
 
 def compare_exceptions(a, b):

--- a/xdggs/tests/matchers.py
+++ b/xdggs/tests/matchers.py
@@ -1,0 +1,67 @@
+import enum
+import re
+from dataclasses import dataclass, field
+
+try:
+    ExceptionGroup
+except NameError:
+    from exceptiongroup import ExceptionGroup
+
+
+class MatchResult(enum.Enum):
+    match = 0
+    mismatched_typing = 1
+    mismatched_message = 2
+
+
+# necessary until pytest-dev/pytest#11538 is resolved
+@dataclass
+class Match:
+    exc: Exception | ExceptionGroup | tuple[Exception | ExceptionGroup, ...]
+    submatchers: list["Match"] = field(default_factory=list)
+    match: str = None
+
+    def __post_init__(self):
+        if not isinstance(self.exc, type | tuple) or not issubclass(
+            self.exc, BaseException
+        ):
+            raise TypeError(f"exception type must be an exception, got: {self.exc}")
+        if not issubclass(self.exc, ExceptionGroup) and self.submatchers:
+            raise TypeError("can only pass sub-matchers for exception groups")
+        if not isinstance(self.match, str) and self.match is not None:
+            raise TypeError("match must be either `None` or a string pattern")
+
+    @classmethod
+    def from_dict(cls, mapping):
+        children = [cls.from_dict(m) for m in mapping.get("children", [])]
+
+        return cls(
+            mapping["exceptions"],
+            submatchers=children,
+            match=mapping.get("match", None),
+        )
+
+    def assert_match(self, exc):
+        assert type(exc) is type(self.exc)  # noqa: E721
+
+        assert re.search(str(exc), self.match), "message does not match"
+
+
+def compare_exceptions(a, b):
+    if type(a) is not type(b):
+        return False
+
+    if isinstance(a, ExceptionGroup):
+        comparison = a.args[0] == b.args[0] and all(
+            compare_exceptions(_a, _b) for _a, _b in zip(a.args[1], b.args[1])
+        )
+    else:
+        comparison = a.args == b.args
+
+    return comparison
+
+
+def assert_exceptions_equal(actual, expected):
+    assert type(actual) is type(expected)
+
+    assert compare_exceptions(actual, expected), "mismatching exceptions"

--- a/xdggs/tests/matchers.py
+++ b/xdggs/tests/matchers.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass, field
 try:
     ExceptionGroup
 except NameError:
-    from exceptiongroup import ExceptionGroup
+    from exceptiongroup import BaseExceptionGroup, ExceptionGroup
 
 
 class MatchResult(enum.Enum):
@@ -21,6 +21,13 @@ def is_exception_spec(exc):
     return all(isinstance(e, type) and issubclass(e, BaseException) for e in exc)
 
 
+def is_exceptiongroup_spec(exc):
+    if not isinstance(exc, tuple):
+        exc = (exc,)
+
+    return all(isinstance(e, type) and issubclass(e, BaseExceptionGroup) for e in exc)
+
+
 # necessary until pytest-dev/pytest#11538 is resolved
 @dataclass
 class Match:
@@ -33,10 +40,7 @@ class Match:
             raise TypeError(
                 f"exception type must be one or more exceptions, got: {self.exc}"
             )
-        if (
-            not (isinstance(self.exc, type) and issubclass(self.exc, ExceptionGroup))
-            and self.submatchers
-        ):
+        if not is_exceptiongroup_spec(self.exc) and self.submatchers:
             raise TypeError("can only pass sub-matchers for exception groups")
         if not isinstance(self.match, str) and self.match is not None:
             raise TypeError("match must be either `None` or a string pattern")

--- a/xdggs/tests/matchers.py
+++ b/xdggs/tests/matchers.py
@@ -27,11 +27,35 @@ def is_exceptiongroup_spec(exc):
     return all(isinstance(e, type) and issubclass(e, BaseExceptionGroup) for e in exc)
 
 
+class Match: ...
+
+
+MatchType = BaseException | Match | tuple[BaseException | Match, ...]
+
+
 # necessary until pytest-dev/pytest#11538 is resolved
 @dataclass
 class Match:
-    exc: Exception | ExceptionGroup | tuple[Exception | ExceptionGroup, ...]
-    submatchers: list["Match"] = field(default_factory=list)
+    """match exceptions and exception groups
+
+    Think of `Match` objects as an equivalent to `re.Pattern` classes.
+
+    Providing a tuple in place of a single exception / matcher means logical "or".
+
+    Parameters
+    ----------
+    exc : exception-like or tuple of exception-like
+        The exceptions or exception groups to match.
+    submatchers : match-like, optional
+        The submatchers for exception groups. Note that matchers with a mixture of
+        exception groups and exceptions can't provide submatchers. If that's what you
+        need, provide a tuple containing multiple matchers.
+    match : str or regex-like, optional
+        A pattern for matching the message of the exception.
+    """
+
+    exc: type[BaseException] | tuple[type[BaseException], ...]
+    submatchers: list[MatchType] = field(default_factory=list)
     match: str = None
 
     def __post_init__(self):

--- a/xdggs/tests/matchers.py
+++ b/xdggs/tests/matchers.py
@@ -85,7 +85,6 @@ class Match:
 
     def matches(self, exc):
         if not isinstance(exc, self.exc):
-            print("type does not match")
             return False
 
         if self.match is not None:
@@ -94,11 +93,24 @@ class Match:
             if match_ is None:
                 return False
 
-        if self.submatchers and not issubclass(self.exc, BaseExceptionGroup):
+        if self.submatchers and not isinstance(exc, BaseExceptionGroup):
             return False
         elif self.submatchers:
-            # TODO: implement the submatchers
-            pass
+            if len(self.submatchers) != len(exc.exceptions):
+                return False
+
+            unmatched_matchers = []
+            exceptions = list(exc.exceptions)
+            for matcher in self.submatchers:
+                for index, exception in enumerate(exceptions):
+                    if matcher.matches(exception):
+                        exceptions.pop(index)
+                        break
+                else:
+                    unmatched_matchers.append(matcher)
+
+            if unmatched_matchers:
+                return False
 
         return True
 

--- a/xdggs/tests/matchers.py
+++ b/xdggs/tests/matchers.py
@@ -75,7 +75,25 @@ def compare_exceptions(a, b):
     return comparison
 
 
-def assert_exceptions_equal(actual, expected):
-    assert type(actual) is type(expected)
+def format_exception_diff(a, b):
+    sections = []
+    if type(a) is not type(b):
+        sections.append("\n".join([f"L  {type(a).__name__}", f"R  {type(b).__name__}"]))
+    else:
+        sections.append(f"{type(a).__name__}")
 
-    assert compare_exceptions(actual, expected), "mismatching exceptions"
+    if isinstance(a, BaseExceptionGroup):
+        if a.message != b.message:
+            sections.append(
+                "\n".join(["Message", f"L  {a.message}", f"R  {b.message}"])
+            )
+        if a.exceptions != b.exceptions:
+            sections.append("\n".join(["Exceptions differ"]))
+    elif str(a) != str(b):
+        sections.append("\n".join(["Message", f"L  {str(a)}", f"R  {str(b)}"]))
+
+    return "\n\n".join(sections)
+
+
+def assert_exceptions_equal(actual, expected):
+    assert compare_exceptions(actual, expected), format_exception_diff(actual, expected)

--- a/xdggs/tests/test_matchers.py
+++ b/xdggs/tests/test_matchers.py
@@ -39,5 +39,41 @@ def test_from_dict(mapping, args, kwargs):
     assert actual == expected
 
 
-def test_single_level_match():
-    pass
+def test_assert_exceptions_equal():
+    actual = ValueError("error message")
+    expected = ValueError("error message")
+
+    matchers.assert_exceptions_equal(actual, expected)
+
+    try:
+        raise ValueError("error message")
+    except ValueError as e:
+        actual = e
+    expected = ValueError("error message")
+
+    matchers.assert_exceptions_equal(actual, expected)
+
+    actual = ValueError("error message")
+    expected = TypeError("error message")
+    with pytest.raises(AssertionError):
+        matchers.assert_exceptions_equal(actual, expected)
+
+    actual = ValueError("error message1")
+    expected = ValueError("error message2")
+    with pytest.raises(AssertionError):
+        matchers.assert_exceptions_equal(actual, expected)
+
+    actual = ExceptionGroup("group message1", [ValueError("error message")])
+    expected = ExceptionGroup("group message2", [ValueError("error message")])
+    with pytest.raises(AssertionError):
+        matchers.assert_exceptions_equal(actual, expected)
+
+    actual = ExceptionGroup("group message", [ValueError("error message1")])
+    expected = ExceptionGroup("group message", [ValueError("error message2")])
+    with pytest.raises(AssertionError):
+        matchers.assert_exceptions_equal(actual, expected)
+
+    actual = ExceptionGroup("group message", [ValueError("error message")])
+    expected = ExceptionGroup("group message", [TypeError("error message")])
+    with pytest.raises(AssertionError):
+        matchers.assert_exceptions_equal(actual, expected)

--- a/xdggs/tests/test_matchers.py
+++ b/xdggs/tests/test_matchers.py
@@ -8,35 +8,42 @@ except NameError:
     from exceptiongroup import ExceptionGroup
 
 
-def test_construct_simple():
-    # simple
-    matchers.Match(ValueError)
-    matchers.Match((ValueError, NameError))
-    matchers.Match(ExceptionGroup)
-    with pytest.raises(
-        TypeError, match="exception type must be one or more exceptions"
-    ):
-        matchers.Match(int)
+class TestMatch:
+    def test_construct_simple(self):
+        # simple
+        matchers.Match(ValueError)
+        matchers.Match((ValueError, NameError))
+        matchers.Match(ExceptionGroup)
+        with pytest.raises(
+            TypeError, match="exception type must be one or more exceptions"
+        ):
+            matchers.Match(int)
 
-    # with match string
-    matchers.Match(TypeError, match="pattern")
-    matchers.Match(ExceptionGroup, match="pattern")
-    with pytest.raises(TypeError):
-        matchers.Match(ValueError, match=int)
+        # with match string
+        matchers.Match(TypeError, match="pattern")
+        matchers.Match(ExceptionGroup, match="pattern")
+        with pytest.raises(TypeError):
+            matchers.Match(ValueError, match=int)
 
-    # with submatchers
-    with pytest.raises(TypeError):
-        matchers.Match(ValueError, submatchers=[matchers.Match(ValueError)])
+        # with submatchers
+        with pytest.raises(TypeError):
+            matchers.Match(ValueError, submatchers=[matchers.Match(ValueError)])
 
-
-@pytest.mark.parametrize(
-    ["mapping", "args", "kwargs"],
-    (({"exceptions": ValueError}, (ValueError,), {}),),
-)
-def test_from_dict(mapping, args, kwargs):
-    actual = matchers.Match.from_dict(mapping)
-    expected = matchers.Match(*args, **kwargs)
-    assert actual == expected
+    @pytest.mark.parametrize(
+        ["mapping", "args", "kwargs"],
+        (
+            ({"exceptions": ValueError}, (ValueError,), {}),
+            (
+                {"exceptions": ValueError, "match": "abc"},
+                (ValueError,),
+                {"match": "abc"},
+            ),
+        ),
+    )
+    def test_from_dict(self, mapping, args, kwargs):
+        actual = matchers.Match.from_dict(mapping)
+        expected = matchers.Match(*args, **kwargs)
+        assert actual == expected
 
 
 def test_assert_exceptions_equal():

--- a/xdggs/tests/test_matchers.py
+++ b/xdggs/tests/test_matchers.py
@@ -1,0 +1,41 @@
+import pytest
+
+from xdggs.tests import matchers
+
+try:
+    ExceptionGroup
+except NameError:
+    from exceptiongroup import ExceptionGroup
+
+
+def test_construct_simple():
+    # simple
+    matchers.Match(ValueError)
+    matchers.Match((ValueError, NameError))
+    matchers.Match(ExceptionGroup)
+    with pytest.raises(TypeError, match="exception type must be an exception"):
+        matchers.Match(int)
+
+    # with match string
+    matchers.Match(TypeError, match="pattern")
+    matchers.Match(ExceptionGroup, match="pattern")
+    with pytest.raises(TypeError):
+        matchers.Match(ValueError, match=int)
+
+    # with submatchers
+    with pytest.raises(TypeError):
+        matchers.Match(ValueError, submatchers=[matchers.Match(ValueError)])
+
+
+@pytest.mark.parametrize(
+    ["mapping", "args", "kwargs"],
+    (({"exceptions": ValueError}, (ValueError,), {}),),
+)
+def test_from_dict(mapping, args, kwargs):
+    actual = matchers.Match.from_dict(mapping)
+    expected = matchers.Match(*args, **kwargs)
+    assert actual == expected
+
+
+def test_single_level_match():
+    pass

--- a/xdggs/tests/test_matchers.py
+++ b/xdggs/tests/test_matchers.py
@@ -45,6 +45,55 @@ class TestMatch:
         expected = matchers.Match(*args, **kwargs)
         assert actual == expected
 
+    @pytest.mark.parametrize(
+        ["exc", "match", "expected"],
+        (
+            pytest.param(
+                ValueError("e"), matchers.Match(ValueError), True, id="exc-wo pat"
+            ),
+            pytest.param(
+                ValueError("error message"),
+                matchers.Match(ValueError, match="message"),
+                True,
+                id="exc-match",
+            ),
+            pytest.param(
+                ValueError("error message"),
+                matchers.Match(ValueError, match="abc"),
+                False,
+                id="exc-no match",
+            ),
+            pytest.param(
+                ExceptionGroup("eg", [ValueError("error")]),
+                matchers.Match(ExceptionGroup),
+                True,
+                id="eg-without pattern-without submatchers",
+            ),
+            pytest.param(
+                ExceptionGroup("error group", [ValueError("error")]),
+                matchers.Match(ExceptionGroup, match="err"),
+                True,
+                id="eg-match-without submatchers",
+            ),
+            pytest.param(
+                ExceptionGroup("eg", [ValueError("error")]),
+                matchers.Match(ExceptionGroup, match="abc"),
+                False,
+                id="eg-no match-without submatchers",
+            ),
+            pytest.param(
+                ExceptionGroup("eg", [ValueError("error")]),
+                matchers.Match(
+                    ExceptionGroup, submatchers=[matchers.Match(ValueError)]
+                ),
+                True,
+                id="eg-wo pat-with submatchers-wo subpat",
+            ),
+        ),
+    )
+    def test_matches(self, exc, match, expected):
+        assert match.matches(exc) == expected
+
 
 def test_assert_exceptions_equal():
     actual = ValueError("error message")

--- a/xdggs/tests/test_matchers.py
+++ b/xdggs/tests/test_matchers.py
@@ -13,7 +13,9 @@ def test_construct_simple():
     matchers.Match(ValueError)
     matchers.Match((ValueError, NameError))
     matchers.Match(ExceptionGroup)
-    with pytest.raises(TypeError, match="exception type must be an exception"):
+    with pytest.raises(
+        TypeError, match="exception type must be one or more exceptions"
+    ):
         matchers.Match(int)
 
     # with match string

--- a/xdggs/tests/test_matchers.py
+++ b/xdggs/tests/test_matchers.py
@@ -49,37 +49,37 @@ class TestMatch:
         ["exc", "match", "expected"],
         (
             pytest.param(
-                ValueError("e"), matchers.Match(ValueError), True, id="exc-wo pat"
+                ValueError("e"), matchers.Match(ValueError), True, id="exc-match-wo pat"
             ),
             pytest.param(
                 ValueError("error message"),
                 matchers.Match(ValueError, match="message"),
                 True,
-                id="exc-match",
+                id="exc-match-w pat",
             ),
             pytest.param(
                 ValueError("error message"),
                 matchers.Match(ValueError, match="abc"),
                 False,
-                id="exc-no match",
+                id="exc-no match-w pat",
             ),
             pytest.param(
                 ExceptionGroup("eg", [ValueError("error")]),
                 matchers.Match(ExceptionGroup),
                 True,
-                id="eg-without pattern-without submatchers",
+                id="eg-match-wo pat-without submatchers",
             ),
             pytest.param(
                 ExceptionGroup("error group", [ValueError("error")]),
                 matchers.Match(ExceptionGroup, match="err"),
                 True,
-                id="eg-match-without submatchers",
+                id="eg-match-w pat-without submatchers",
             ),
             pytest.param(
                 ExceptionGroup("eg", [ValueError("error")]),
                 matchers.Match(ExceptionGroup, match="abc"),
                 False,
-                id="eg-no match-without submatchers",
+                id="eg-no match-w pat-without submatchers",
             ),
             pytest.param(
                 ExceptionGroup("eg", [ValueError("error")]),
@@ -87,7 +87,31 @@ class TestMatch:
                     ExceptionGroup, submatchers=[matchers.Match(ValueError)]
                 ),
                 True,
-                id="eg-wo pat-with submatchers-wo subpat",
+                id="eg-match-wo pat-with submatchers-wo subpat",
+            ),
+            pytest.param(
+                ExceptionGroup("eg", [ValueError("error")]),
+                matchers.Match(ExceptionGroup, submatchers=[matchers.Match(TypeError)]),
+                False,
+                id="eg-no match-wo pat-with submatchers-wo subpat",
+            ),
+            pytest.param(
+                ExceptionGroup("eg", [ValueError("error")]),
+                matchers.Match(
+                    ExceptionGroup,
+                    submatchers=[matchers.Match(ValueError, match="err")],
+                ),
+                True,
+                id="eg-match-w pat-with submatchers-wo subpat",
+            ),
+            pytest.param(
+                ExceptionGroup("eg", [ValueError("error")]),
+                matchers.Match(
+                    ExceptionGroup,
+                    submatchers=[matchers.Match(ValueError, match="abc")],
+                ),
+                False,
+                id="eg-no match-w pat-with submatchers-wo subpat",
             ),
         ),
     )


### PR DESCRIPTION
We're making use of exception groups in the grid objects to return all issues with the attributes in a single exception group. However, `pytest` does not support matching exception groups (instead, its documentation states that `excinfo.group_contains` should be used to assert the structure of the caught exception group).

While possible, this means we can't use `parametrize` to generate lots of test cases.

Instead, here's two ways to make assertions about the structure of a exception group:
- using `Match` objects that aim to support nested `pytest.raises`-style checks
- using `assert_exceptions_equal`, which compares two exceptions and raises a (somewhat) informative error