### PR TITLE
move the conversion methods to the grid object

### DIFF
--- a/xdggs/grid.py
+++ b/xdggs/grid.py
@@ -27,3 +27,9 @@ class DGGSInfo:
 
     def to_dict(self: Self) -> dict[str, Any]:
         return {"resolution": self.resolution}
+
+    def cell_ids2geographic(self, cell_ids):
+        raise NotImplementedError()
+
+    def geographic2cell_ids(self, lon, lat):
+        raise NotImplementedError()

--- a/xdggs/h3.py
+++ b/xdggs/h3.py
@@ -35,6 +35,14 @@ class H3Info(DGGSInfo):
     def to_dict(self: Self) -> dict[str, Any]:
         return {"grid_name": "h3", "resolution": self.resolution}
 
+    def cell_ids2geographic(
+        self, cell_ids: np.ndarray
+    ) -> tuple[np.ndarray, np.ndarray]:
+        return cells_to_coordinates(cell_ids, radians=False)
+
+    def geographic2cell_ids(self, lon, lat):
+        return coordinates_to_cells(lat, lon, self.resolution, radians=False)
+
 
 @register_dggs("h3")
 class H3Index(DGGSIndex):

--- a/xdggs/h3.py
+++ b/xdggs/h3.py
@@ -76,11 +76,5 @@ class H3Index(DGGSIndex):
     def _replace(self, new_pd_index: PandasIndex):
         return type(self)(new_pd_index, self._dim, self._grid)
 
-    def _latlon2cellid(self, lat: Any, lon: Any) -> np.ndarray:
-        return coordinates_to_cells(lat, lon, self._grid.resolution, radians=False)
-
-    def _cellid2latlon(self, cell_ids: Any) -> tuple[np.ndarray, np.ndarray]:
-        return cells_to_coordinates(cell_ids, radians=False)
-
     def _repr_inline_(self, max_width: int):
         return f"H3Index(resolution={self._grid.resolution})"

--- a/xdggs/healpix.py
+++ b/xdggs/healpix.py
@@ -127,6 +127,14 @@ class HealpixInfo(DGGSInfo):
             "rotation": self.rotation,
         }
 
+    def cell_ids2geographic(self, cell_ids):
+        lon, lat = healpy.pix2ang(self.nside, cell_ids, nest=self.nest, lonlat=True)
+
+        return lon, lat
+
+    def geographic2cell_ids(self, lon, lat):
+        return healpy.ang2pix(self.nside, lon, lat, lonlat=True, nest=self.nest)
+
 
 @register_dggs("healpix")
 class HealpixIndex(DGGSIndex):

--- a/xdggs/healpix.py
+++ b/xdggs/healpix.py
@@ -165,19 +165,6 @@ class HealpixIndex(DGGSIndex):
     def _replace(self, new_pd_index: PandasIndex):
         return type(self)(new_pd_index, self._dim, self._grid)
 
-    def _latlon2cellid(self, lat: Any, lon: Any) -> np.ndarray:
-        # TODO apply rotation
-        return healpy.ang2pix(
-            self._grid.nside, lon, lat, lonlat=True, nest=self._grid.nest
-        )
-
-    def _cellid2latlon(self, cell_ids: Any) -> tuple[np.ndarray, np.ndarray]:
-        lon, lat = healpy.pix2ang(
-            self._grid.nside, cell_ids, nest=self._grid.nest, lonlat=True
-        )
-
-        return lon, lat
-
     @property
     def grid_info(self) -> HealpixInfo:
         return self._grid

--- a/xdggs/tests/test_h3.py
+++ b/xdggs/tests/test_h3.py
@@ -92,6 +92,28 @@ class TestH3Info:
 
         assert actual == mapping
 
+    @pytest.mark.parametrize(
+        ["cell_ids", "cell_centers"], list(zip(cell_ids, cell_centers))
+    )
+    def test_cell_ids2geographic(self, cell_ids, cell_centers):
+        grid = h3.H3Info(resolution=3)
+
+        actual = grid.cell_ids2geographic(cell_ids)
+        expected = cell_centers
+
+        np.testing.assert_allclose(actual, expected)
+
+    @pytest.mark.parametrize(
+        ["cell_centers", "cell_ids"], list(zip(cell_centers, cell_ids))
+    )
+    def test_geographic2cell_ids(self, cell_centers, cell_ids):
+        grid = h3.H3Info(resolution=3)
+
+        actual = grid.geographic2cell_ids(cell_centers[:, 1], cell_centers[:, 0])
+        expected = cell_ids
+
+        np.testing.assert_equal(actual, expected)
+
 
 @pytest.mark.parametrize("resolution", resolutions)
 @pytest.mark.parametrize("dim", dims)
@@ -151,32 +173,6 @@ def test_replace(old_variable, new_variable):
     assert new_index._grid == index._grid
     assert new_index._dim == index._dim
     assert new_index._pd_index == new_pandas_index
-
-
-@pytest.mark.parametrize(
-    ["cell_ids", "cell_centers"], list(zip(cell_ids, cell_centers))
-)
-def test_cellid2latlon(cell_ids, cell_centers):
-    grid = h3.H3Info(resolution=3)
-    index = h3.H3Index(cell_ids=cell_ids, dim="cells", grid_info=grid)
-
-    actual = index._cellid2latlon(cell_ids)
-    expected = cell_centers
-
-    np.testing.assert_allclose(actual, expected)
-
-
-@pytest.mark.parametrize(
-    ["cell_centers", "cell_ids"], list(zip(cell_centers, cell_ids))
-)
-def test_latlon2cellid(cell_centers, cell_ids):
-    grid = h3.H3Info(resolution=3)
-    index = h3.H3Index(cell_ids=[0], dim="cells", grid_info=grid)
-
-    actual = index._latlon2cellid(cell_centers[:, 0], cell_centers[:, 1])
-    expected = cell_ids
-
-    np.testing.assert_equal(actual, expected)
 
 
 @pytest.mark.parametrize("max_width", [20, 50, 80, 120])

--- a/xdggs/tests/test_healpix.py
+++ b/xdggs/tests/test_healpix.py
@@ -112,6 +112,53 @@ class strategies:
         return cell_ids_, grids_
 
 
+options = [{}]
+variable_names = ["cell_ids", "zonal_ids", "zone_ids"]
+variables = [
+    xr.Variable(
+        "cells",
+        np.array([3]),
+        {
+            "grid_name": "healpix",
+            "resolution": 0,
+            "indexing_scheme": "nested",
+            "rotation": (0, 0),
+        },
+    ),
+    xr.Variable(
+        "zones",
+        np.array([3]),
+        {
+            "grid_name": "healpix",
+            "resolution": 0,
+            "indexing_scheme": "ring",
+            "rotation": (0, 0),
+        },
+    ),
+    xr.Variable(
+        "cells",
+        np.array([5, 11, 21]),
+        {
+            "grid_name": "healpix",
+            "resolution": 1,
+            "indexing_scheme": "nested",
+            "rotation": (0, 0),
+        },
+    ),
+    xr.Variable(
+        "zones",
+        np.array([54, 70, 82, 91]),
+        {
+            "grid_name": "healpix",
+            "resolution": 3,
+            "indexing_scheme": "nested",
+            "rotation": (0, 0),
+        },
+    ),
+]
+variable_combinations = list(itertools.product(variables, repeat=2))
+
+
 class TestHealpixInfo:
     @given(strategies.invalid_resolutions)
     def test_init_invalid_resolutions(self, resolution):
@@ -189,52 +236,82 @@ class TestHealpixInfo:
 
         assert roundtripped == mapping
 
+    @given(
+        *strategies.grid_and_cell_ids(
+            indexing_schemes=st.sampled_from(["nested", "ring"]),
+            dtypes=st.sampled_from(["int64"]),
+        )
+    )
+    def test_cell_center_roundtrip(self, cell_ids, grid) -> None:
+        centers = grid.cell_ids2geographic(cell_ids)
 
-options = [{}]
-variable_names = ["cell_ids", "zonal_ids", "zone_ids"]
-variables = [
-    xr.Variable(
-        "cells",
-        np.array([3]),
-        {
-            "grid_name": "healpix",
-            "resolution": 0,
-            "indexing_scheme": "nested",
-            "rotation": (0, 0),
-        },
-    ),
-    xr.Variable(
-        "zones",
-        np.array([3]),
-        {
-            "grid_name": "healpix",
-            "resolution": 0,
-            "indexing_scheme": "ring",
-            "rotation": (0, 0),
-        },
-    ),
-    xr.Variable(
-        "cells",
-        np.array([5, 11, 21]),
-        {
-            "grid_name": "healpix",
-            "resolution": 1,
-            "indexing_scheme": "nested",
-            "rotation": (0, 0),
-        },
-    ),
-    xr.Variable(
-        "zones",
-        np.array([54, 70, 82, 91]),
-        {
-            "grid_name": "healpix",
-            "resolution": 3,
-            "indexing_scheme": "nested",
-            "rotation": (0, 0),
-        },
-    ),
-]
-variable_combinations = list(itertools.product(variables, repeat=2))
+        roundtripped = grid.geographic2cell_ids(lat=centers[1], lon=centers[0])
+
+        np.testing.assert_equal(roundtripped, cell_ids)
+
+    @pytest.mark.parametrize(
+        ["cell_ids", "resolution", "indexing_scheme", "expected"],
+        (
+            pytest.param(
+                np.array([3]),
+                1,
+                "ring",
+                (np.array([315.0]), np.array([66.44353569089877])),
+            ),
+            pytest.param(
+                np.array([5, 11, 21]),
+                3,
+                "nested",
+                (
+                    np.array([61.875, 33.75, 84.375]),
+                    np.array([19.47122063, 24.62431835, 41.8103149]),
+                ),
+            ),
+        ),
+    )
+    def test_cell_ids2geographic(
+        self, cell_ids, resolution, indexing_scheme, expected
+    ) -> None:
+        grid = healpix.HealpixInfo(
+            resolution=resolution, indexing_scheme=indexing_scheme
+        )
+
+        actual_lon, actual_lat = grid.cell_ids2geographic(cell_ids)
+
+        np.testing.assert_allclose(actual_lon, expected[0])
+        np.testing.assert_allclose(actual_lat, expected[1])
+
+    @pytest.mark.parametrize(
+        ["cell_centers", "resolution", "indexing_scheme", "expected"],
+        (
+            pytest.param(
+                np.array([[315.0, 66.44353569089877]]),
+                1,
+                "ring",
+                np.array([3]),
+            ),
+            pytest.param(
+                np.array(
+                    [[61.875, 19.47122063], [33.75, 24.62431835], [84.375, 41.8103149]]
+                ),
+                3,
+                "nested",
+                np.array([5, 11, 21]),
+            ),
+        ),
+    )
+    def test_geographic2cell_ids(
+        self, cell_centers, resolution, indexing_scheme, expected
+    ) -> None:
+        grid = healpix.HealpixInfo(
+            resolution=resolution, indexing_scheme=indexing_scheme
+        )
+
+        actual = grid.geographic2cell_ids(
+            lon=cell_centers[:, 0], lat=cell_centers[:, 1]
+        )
+
+        np.testing.assert_equal(actual, expected)
 
 
 @pytest.mark.parametrize(
@@ -338,21 +415,6 @@ class TestHealpixIndex:
 
         np.testing.assert_equal(index._pd_index.index.values, cell_ids)
 
-    @given(
-        *strategies.grid_and_cell_ids(
-            indexing_schemes=st.sampled_from(["nested", "ring"]),
-            dtypes=st.sampled_from(["int64"]),
-        )
-    )
-    def test_cell_center_roundtrip(self, cell_ids, grid) -> None:
-        index = healpix.HealpixIndex(cell_ids, dim="cells", grid_info=grid)
-
-        centers = index._cellid2latlon(cell_ids)
-
-        roundtripped = index._latlon2cellid(lat=centers[1], lon=centers[0])
-
-        np.testing.assert_equal(roundtripped, cell_ids)
-
     @given(strategies.grids())
     def test_grid(self, grid):
         index = healpix.HealpixIndex([0], dim="cells", grid_info=grid)
@@ -399,68 +461,6 @@ def test_replace(old_variable, new_variable) -> None:
     assert new_index._dim == index._dim
     assert new_index._pd_index == new_pandas_index
     assert index._grid == grid
-
-
-@pytest.mark.parametrize(
-    ["cell_ids", "resolution", "indexing_scheme", "expected"],
-    (
-        pytest.param(
-            np.array([3]),
-            1,
-            "ring",
-            (np.array([315.0]), np.array([66.44353569089877])),
-        ),
-        pytest.param(
-            np.array([5, 11, 21]),
-            3,
-            "nested",
-            (
-                np.array([61.875, 33.75, 84.375]),
-                np.array([19.47122063, 24.62431835, 41.8103149]),
-            ),
-        ),
-    ),
-)
-def test_cellid2latlon(cell_ids, resolution, indexing_scheme, expected) -> None:
-    grid_info = healpix.HealpixInfo(
-        resolution=resolution, indexing_scheme=indexing_scheme
-    )
-    index = healpix.HealpixIndex(cell_ids=[0], dim="cells", grid_info=grid_info)
-
-    actual_lon, actual_lat = index._cellid2latlon(cell_ids)
-
-    np.testing.assert_allclose(actual_lon, expected[0])
-    np.testing.assert_allclose(actual_lat, expected[1])
-
-
-@pytest.mark.parametrize(
-    ["cell_centers", "resolution", "indexing_scheme", "expected"],
-    (
-        pytest.param(
-            np.array([[315.0, 66.44353569089877]]),
-            1,
-            "ring",
-            np.array([3]),
-        ),
-        pytest.param(
-            np.array(
-                [[61.875, 19.47122063], [33.75, 24.62431835], [84.375, 41.8103149]]
-            ),
-            3,
-            "nested",
-            np.array([5, 11, 21]),
-        ),
-    ),
-)
-def test_latlon2cell_ids(cell_centers, resolution, indexing_scheme, expected) -> None:
-    grid_info = healpix.HealpixInfo(
-        resolution=resolution, indexing_scheme=indexing_scheme
-    )
-    index = healpix.HealpixIndex(cell_ids=[0], dim="cells", grid_info=grid_info)
-
-    actual = index._latlon2cellid(lon=cell_centers[:, 0], lat=cell_centers[:, 1])
-
-    np.testing.assert_equal(actual, expected)
 
 
 @pytest.mark.parametrize("max_width", [20, 50, 80, 120])


### PR DESCRIPTION
As mentioned in https://github.com/xarray-contrib/xdggs/issues/35#issuecomment-2109655401, this moves the conversion methods of cell ids to / from geographic latitude / longitude coordinates to the grid info objects. The advantage of this is that testing and reusing the grid objects become easier.