### PR TITLE
install `h3ronpy` from the new subdirectory

### DIFF
--- a/ci/install-upstream-wheels.sh
+++ b/ci/install-upstream-wheels.sh
@@ -36,7 +36,7 @@ python -m pip install \
 python -m pip install --no-deps --upgrade \
     git+https://github.com/Unidata/cftime \
     git+https://github.com/astropy/astropy \
-    git+https://github.com/nmandery/h3ronpy
+    "git+https://github.com/nmandery/h3ronpy#subdirectory=h3ronpy"
 
 # install healpy from github
 # need to run `auditwheel` to include the shared libs


### PR DESCRIPTION
The `h3ronpy` project moved the `h3ronpy` code into a subdirectory (converting the repository into a monorepo). To still be able to install `h3ronpy`, we have to specify the subdirectory.