### PR TITLE
`pre-commit` maintenance

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -13,12 +13,12 @@ repos:
       - id: prettier
         args: [--cache-location=.prettier_cache/cache]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.3.5
+    rev: v0.4.9
     hooks:
       - id: ruff
         args: [--fix]
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.3.0
+    rev: 24.4.2
     hooks:
       - id: black-jupyter
   - repo: https://github.com/kynan/nbstripout

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,12 @@ repos:
     rev: 24.4.2
     hooks:
       - id: black-jupyter
+  - repo: https://github.com/keewis/blackdoc
+    rev: v0.3.9
+    hooks:
+      - id: blackdoc
+        additional_dependencies: ["black==24.4.2"]
+      - id: blackdoc-autoupdate-black
   - repo: https://github.com/kynan/nbstripout
     rev: 0.7.1
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,10 @@ known-third-party=[
     "h3ronpy",
 ]
 
+[tool.ruff.lint.flake8-tidy-imports]
+# Disallow all relative imports.
+ban-relative-imports = "all"
+
 [tool.coverage.run]
 source = ["xdggs"]
 branch = true


### PR DESCRIPTION
- get `ruff` to apply the "absolute-imports" rule
- apply `black` to examples in docstrings