### PR TITLE
hierarchical operations on cell ids: parents

### DIFF
--- a/xdggs/accessor.py
+++ b/xdggs/accessor.py
@@ -118,4 +118,9 @@ class DGGSAccessor:
         parents : DataArray
             The parent cell ids, one for each input cell.
         """
-        return self.index.parents(resolution)
+        data = self.index.parents(resolution)
+
+        params = self.grid_info.to_dict()
+        params["resolution"] = resolution
+
+        return self.coord.copy(data=data).assign_attrs(**params).rename("parents")

--- a/xdggs/accessor.py
+++ b/xdggs/accessor.py
@@ -104,3 +104,18 @@ class DGGSAccessor:
                 "longitude": (self.index._dim, lon_data),
             }
         )
+
+    def parents(self, resolution: int) -> xr.DataArray:
+        """determine the parent cell ids of the cells
+
+        Parameters
+        ----------
+        resolution : int
+            The parent resolution. Must be smaller than the current resolution.
+
+        Returns
+        -------
+        parents : DataArray
+            The parent cell ids, one for each input cell.
+        """
+        return self.index.parents(resolution)

--- a/xdggs/h3.py
+++ b/xdggs/h3.py
@@ -9,6 +9,7 @@ except ImportError:  # pragma: no cover
 
 import numpy as np
 import xarray as xr
+from h3ronpy.arrow import change_resolution
 from h3ronpy.arrow.vector import cells_to_coordinates, coordinates_to_cells
 from xarray.indexes import PandasIndex
 
@@ -44,6 +45,14 @@ class H3Info(DGGSInfo):
 
     def geographic2cell_ids(self, lon, lat):
         return coordinates_to_cells(lat, lon, self.resolution, radians=False)
+
+    def parents(self, cell_ids, resolution):
+        if resolution >= self.resolution:
+            raise ValueError(
+                f"resolution is not a parent: {resolution} >= {self.resolution}"
+            )
+
+        return change_resolution(cell_ids, resolution)
 
 
 @register_dggs("h3")

--- a/xdggs/healpix.py
+++ b/xdggs/healpix.py
@@ -135,6 +135,19 @@ class HealpixInfo(DGGSInfo):
     def geographic2cell_ids(self, lon, lat):
         return healpy.ang2pix(self.nside, lon, lat, lonlat=True, nest=self.nest)
 
+    def parents(self, cell_ids, resolution):
+        if resolution >= self.resolution:
+            raise ValueError(
+                f"resolution is not a parent: {resolution} >= {self.resolution}"
+            )
+
+        offset = self.resolution - resolution
+        x, y, f = healpy.pix2xyf(self.nside, cell_ids, nest=self.nest)
+        x_ = x >> offset
+        y_ = y >> offset
+
+        return healpy.xyf2pix(2**resolution, x_, y_, f, nest=self.nest)
+
 
 @register_dggs("healpix")
 class HealpixIndex(DGGSIndex):

--- a/xdggs/index.py
+++ b/xdggs/index.py
@@ -72,6 +72,9 @@ class DGGSIndex(Index):
     def cell_centers(self) -> tuple[np.ndarray, np.ndarray]:
         return self._grid.cell_ids2geographic(self._pd_index.index.values)
 
+    def parents(self, resolution: int) -> np.ndarray:
+        return self._grid.parents(self._pd_index.index.values, resolution=resolution)
+
     @property
     def grid_info(self) -> DGGSInfo:
         return self._grid


### PR DESCRIPTION
Towards https://github.com/xarray-contrib/xdggs/issues/38#issuecomment-2007410538: this computes the parents at the given resolution for every cell id. This is similar to `h3ronpy.pandas.change_resolution_paired` (as mentioned in #18), with the restriction that it is only possible to compute the parents.

Note that this does not aim to perform any sort of aggregation / interpolation / reindexing. In other words, this is purely a cell id operation.

In theory, we could expand this to also return the children, but then size of the `cells` dim would change, and we'd get duplicated entries in `cell_ids` coordinate.

Tests are still missing, I'll add them once we settled on a design.