### PR TITLE
require the dependencies of `explore`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,14 +34,10 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "xarray",
-    "healpy",
-    "h3ronpy",
-    "typing-extensions",
-]
-
-[project.optional-dependencies]
-explore = [
+  "xarray",
+  "healpy",
+  "h3ronpy",
+  "typing-extensions",
   "lonboard>=0.9.3",
   "pyproj>=3.3",
   "matplotlib",


### PR DESCRIPTION
- follow-up to #70