### PR TITLE
remove the `rotation` parameter of `healpix`

### DIFF
--- a/xdggs/healpix.py
+++ b/xdggs/healpix.py
@@ -1,7 +1,7 @@
 import json
 import operator
 from collections.abc import Mapping
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any, ClassVar, Literal, TypeVar
 
 try:
@@ -99,8 +99,6 @@ class HealpixInfo(DGGSInfo):
 
     indexing_scheme: Literal["nested", "ring", "unique"] = "nested"
 
-    rotation: list[float, float] = field(default_factory=lambda: [0.0, 0.0])
-
     valid_parameters: ClassVar[dict[str, Any]] = {
         "resolution": range(0, 29 + 1),
         "indexing_scheme": ["nested", "ring", "unique"],
@@ -113,11 +111,6 @@ class HealpixInfo(DGGSInfo):
         if self.indexing_scheme not in self.valid_parameters["indexing_scheme"]:
             raise ValueError(
                 f"indexing scheme must be one of {self.valid_parameters['indexing_scheme']}"
-            )
-
-        if np.any(np.isnan(self.rotation) | np.isinf(self.rotation)):
-            raise ValueError(
-                f"rotation must consist of finite values, got {self.rotation}"
             )
 
     @property
@@ -149,10 +142,6 @@ class HealpixInfo(DGGSInfo):
             "level": ("resolution", identity),
             "depth": ("resolution", identity),
             "nest": ("indexing_scheme", lambda nest: "nested" if nest else "ring"),
-            "rot_latlon": (
-                "rotation",
-                lambda rot_latlon: (rot_latlon[1], rot_latlon[0]),
-            ),
         }
 
         def translate(name, value):
@@ -191,7 +180,6 @@ class HealpixInfo(DGGSInfo):
             "grid_name": "healpix",
             "resolution": self.resolution,
             "indexing_scheme": self.indexing_scheme,
-            "rotation": self.rotation,
         }
 
     def cell_ids2geographic(self, cell_ids):
@@ -261,4 +249,4 @@ class HealpixIndex(DGGSIndex):
         return self._grid
 
     def _repr_inline_(self, max_width: int):
-        return f"HealpixIndex(nside={self._grid.resolution}, indexing_scheme={self._grid.indexing_scheme}, rotation={self._grid.rotation!r})"
+        return f"HealpixIndex(nside={self._grid.resolution}, indexing_scheme={self._grid.indexing_scheme})"

--- a/xdggs/tests/test_healpix.py
+++ b/xdggs/tests/test_healpix.py
@@ -29,11 +29,6 @@ class strategies:
         lambda x: x not in ["nested", "ring", "unique"]
     )
 
-    def rotations():
-        lon_rotation = st.floats(min_value=-180.0, max_value=360.0)
-        lat_rotation = st.floats(min_value=-90.0, max_value=90.0)
-        return st.tuples(lon_rotation, lat_rotation)
-
     dims = xrst.names()
 
     @classmethod
@@ -46,8 +41,6 @@ class strategies:
             "order": cls.resolutions,
             "indexing_scheme": cls.indexing_schemes,
             "nest": st.booleans(),
-            "rotation": cls.rotations(),
-            "rot_latlon": cls.rotations().map(lambda x: x[::-1]),
         }
 
         names = {
@@ -55,7 +48,6 @@ class strategies:
                 ["resolution", "nside", "depth", "level", "order"]
             ),
             "indexing_scheme": st.sampled_from(["indexing_scheme", "nest"]),
-            "rotation": st.sampled_from(["rotation", "rot_latlon"]),
         }
 
         return st.builds(lambda **x: list(x.values()), **names).flatmap(
@@ -81,13 +73,11 @@ class strategies:
     def grids(
         resolutions=resolutions,
         indexing_schemes=indexing_schemes,
-        rotations=rotations(),
     ):
         return st.builds(
             healpix.HealpixInfo,
             resolution=resolutions,
             indexing_scheme=indexing_schemes,
-            rotation=rotations,
         )
 
     @classmethod
@@ -95,7 +85,6 @@ class strategies:
         cls,
         resolutions=resolutions,
         indexing_schemes=indexing_schemes,
-        rotations=rotations(),
         dtypes=None,
     ):
         cell_resolutions = st.shared(resolutions, key="common-resolutions")
@@ -108,7 +97,6 @@ class strategies:
         grids_ = cls.grids(
             resolutions=grid_resolutions,
             indexing_schemes=indexing_schemes,
-            rotations=rotations,
         )
 
         return cell_ids_, grids_
@@ -124,7 +112,6 @@ variables = [
             "grid_name": "healpix",
             "resolution": 0,
             "indexing_scheme": "nested",
-            "rotation": (0, 0),
         },
     ),
     xr.Variable(
@@ -134,7 +121,6 @@ variables = [
             "grid_name": "healpix",
             "resolution": 0,
             "indexing_scheme": "ring",
-            "rotation": (0, 0),
         },
     ),
     xr.Variable(
@@ -144,7 +130,6 @@ variables = [
             "grid_name": "healpix",
             "resolution": 1,
             "indexing_scheme": "nested",
-            "rotation": (0, 0),
         },
     ),
     xr.Variable(
@@ -154,7 +139,6 @@ variables = [
             "grid_name": "healpix",
             "resolution": 3,
             "indexing_scheme": "nested",
-            "rotation": (0, 0),
         },
     ),
 ]
@@ -177,15 +161,14 @@ class TestHealpixInfo:
                 indexing_scheme=indexing_scheme,
             )
 
-    @given(strategies.resolutions, strategies.indexing_schemes, strategies.rotations())
-    def test_init(self, resolution, indexing_scheme, rotation):
+    @given(strategies.resolutions, strategies.indexing_schemes)
+    def test_init(self, resolution, indexing_scheme):
         grid = healpix.HealpixInfo(
-            resolution=resolution, indexing_scheme=indexing_scheme, rotation=rotation
+            resolution=resolution, indexing_scheme=indexing_scheme
         )
 
         assert grid.resolution == resolution
         assert grid.indexing_scheme == indexing_scheme
-        assert grid.rotation == rotation
 
     @given(strategies.resolutions)
     def test_nside(self, resolution):
@@ -211,26 +194,24 @@ class TestHealpixInfo:
     def test_from_dict(self, mapping) -> None:
         healpix.HealpixInfo.from_dict(mapping)
 
-    @given(strategies.resolutions, strategies.indexing_schemes, strategies.rotations())
-    def test_to_dict(self, resolution, indexing_scheme, rotation) -> None:
+    @given(strategies.resolutions, strategies.indexing_schemes)
+    def test_to_dict(self, resolution, indexing_scheme) -> None:
         grid = healpix.HealpixInfo(
-            resolution=resolution, indexing_scheme=indexing_scheme, rotation=rotation
+            resolution=resolution, indexing_scheme=indexing_scheme
         )
         actual = grid.to_dict()
 
-        assert set(actual) == {"grid_name", "resolution", "indexing_scheme", "rotation"}
+        assert set(actual) == {"grid_name", "resolution", "indexing_scheme"}
         assert actual["grid_name"] == "healpix"
         assert actual["resolution"] == resolution
         assert actual["indexing_scheme"] == indexing_scheme
-        assert actual["rotation"] == rotation
 
-    @given(strategies.resolutions, strategies.indexing_schemes, strategies.rotations())
-    def test_roundtrip(self, resolution, indexing_scheme, rotation):
+    @given(strategies.resolutions, strategies.indexing_schemes)
+    def test_roundtrip(self, resolution, indexing_scheme):
         mapping = {
             "grid_name": "healpix",
             "resolution": resolution,
             "indexing_scheme": indexing_scheme,
-            "rotation": rotation,
         }
 
         grid = healpix.HealpixInfo.from_dict(mapping)
@@ -404,23 +385,22 @@ class TestHealpixInfo:
     ["mapping", "expected"],
     (
         pytest.param(
-            {"resolution": 10, "indexing_scheme": "nested", "rotation": (0.0, 0.0)},
-            {"resolution": 10, "indexing_scheme": "nested", "rotation": (0.0, 0.0)},
+            {"resolution": 10, "indexing_scheme": "nested"},
+            {"resolution": 10, "indexing_scheme": "nested"},
             id="no_translation",
         ),
         pytest.param(
             {
                 "resolution": 10,
                 "indexing_scheme": "nested",
-                "rotation": (0.0, 0.0),
                 "grid_name": "healpix",
             },
-            {"resolution": 10, "indexing_scheme": "nested", "rotation": (0.0, 0.0)},
+            {"resolution": 10, "indexing_scheme": "nested"},
             id="no_translation-grid_name",
         ),
         pytest.param(
-            {"nside": 1024, "indexing_scheme": "nested", "rotation": (0.0, 0.0)},
-            {"resolution": 10, "indexing_scheme": "nested", "rotation": (0.0, 0.0)},
+            {"nside": 1024, "indexing_scheme": "nested"},
+            {"resolution": 10, "indexing_scheme": "nested"},
             id="nside-alone",
         ),
         pytest.param(
@@ -428,7 +408,6 @@ class TestHealpixInfo:
                 "nside": 1024,
                 "resolution": 10,
                 "indexing_scheme": "nested",
-                "rotation": (0.0, 0.0),
             },
             ExceptionGroup(
                 "received multiple values for parameters",
@@ -445,7 +424,6 @@ class TestHealpixInfo:
                 "resolution": 10,
                 "indexing_scheme": "nested",
                 "nest": True,
-                "rotation": (0.0, 0.0),
             },
             ExceptionGroup(
                 "received multiple values for parameters",
@@ -463,7 +441,6 @@ class TestHealpixInfo:
                 "resolution": 10,
                 "indexing_scheme": "nested",
                 "nest": True,
-                "rotation": (0.0, 0.0),
             },
             ExceptionGroup(
                 "received multiple values for parameters",
@@ -514,7 +491,6 @@ class TestHealpixIndex:
 def test_from_variables(variable_name, variable, options) -> None:
     expected_resolution = variable.attrs["resolution"]
     expected_scheme = variable.attrs["indexing_scheme"]
-    expected_rot = variable.attrs["rotation"]
 
     variables = {variable_name: variable}
 
@@ -522,7 +498,6 @@ def test_from_variables(variable_name, variable, options) -> None:
 
     assert index._grid.resolution == expected_resolution
     assert index._grid.indexing_scheme == expected_scheme
-    assert index._grid.rotation == expected_rot
 
     assert (index._dim,) == variable.dims
     np.testing.assert_equal(index._pd_index.index.values, variable.data)
@@ -552,9 +527,7 @@ def test_replace(old_variable, new_variable) -> None:
 @pytest.mark.parametrize("max_width", [20, 50, 80, 120])
 @pytest.mark.parametrize("resolution", [0, 1, 3])
 def test_repr_inline(resolution, max_width) -> None:
-    grid_info = healpix.HealpixInfo(
-        resolution=resolution, indexing_scheme="nested", rotation=(0, 0)
-    )
+    grid_info = healpix.HealpixInfo(resolution=resolution, indexing_scheme="nested")
     index = healpix.HealpixIndex(cell_ids=[0], dim="cells", grid_info=grid_info)
 
     actual = index._repr_inline_(max_width)


### PR DESCRIPTION
This parameter never really worked properly (rotation along longitude might have been fine, but a rotation that changes the latitudes requires rotating the full vectors), and the main reason we ever supported that was that the convolution method we used a year ago needed that to support arbitrary locations on earth.

However, this was restricted to single base cells and ignored the geometry of healpix cells. This lead to the development of [healpix-convolution](https://github.com/IAOCEA/healpix-convolution/), which means we can drop the `rotation` parameter entirely.