### PR TITLE
`pre-commit` hook maintenance

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,5 +34,5 @@ repos:
         args: [--extra-keys=metadata.kernelspec metadata.langauge_info.version]
 
 ci:
-  autofix_prs: false
+  autofix_prs: true
   autoupdate_schedule: quarterly

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,8 +7,8 @@ repos:
       - id: check-docstring-first
       - id: check-yaml
       - id: check-toml
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
+  - repo: https://github.com/rbubley/mirrors-prettier
+    rev: v3.3.3
     hooks:
       - id: prettier
         args: [--cache-location=.prettier_cache/cache]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,4 +35,4 @@ repos:
 
 ci:
   autofix_prs: true
-  autoupdate_schedule: quarterly
+  autoupdate_schedule: monthly


### PR DESCRIPTION
- allow autofixing PRs
- increase the update frequency of hooks
- use the right mirror for `prettier` (the old one is discontinued)