### PR TITLE
Fix headings in tutorials

### DIFF
--- a/docs/tutorials/h3.ipynb
+++ b/docs/tutorials/h3.ipynb
@@ -1,9 +1,27 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "# Working with H3 data\n",
+    "\n",
+    "H3 is a popular icosahedral DGGS with hexagonal cells, developed and popularized by Uber. For more information, see https://h3geo.org. The tutorial aims to showcase how to work with H3 data using `xdggs`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
+    "## Load libraries"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -16,20 +34,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1",
+   "id": "3",
    "metadata": {},
    "source": [
-    "# Working with H3 data\n",
-    "\n",
-    "H3 is a popular icosahedral DGGS with hexagonal cells, developed and popularized by Uber. For more information, see https://h3geo.org"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "2",
-   "metadata": {},
-   "source": [
-    "## initialization\n",
+    "## Initialization\n",
     "\n",
     "To initialize, we first have to open the dataset. Here we'll use `xarray`'s `air_temperature` tutorial dataset, which was interpolated to the H3 grid.\n",
     "\n",
@@ -45,7 +53,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -56,17 +64,17 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "source": [
     "After that, we can use {py:func}`xdggs.decode` to tell `xdggs` to interpret the cell ids.\n",
     "\n",
-    "This will create a grid object (see {py:attr}`xarray.Dataset.dggs.grid_info` and {py:class}`xdggs.H3Info` for more information) containing the grid parameters and a custom index for the `cell_ids` coordinate (notice how the coordinate name is displayed in bold?), which will allow us to perform grid-aware operations.\n",
+    "This will create a grid object (see {py:attr}`xarray.Dataset.dggs.grid_info` and {py:class}`xdggs.H3Info` for more information) containing the grid parameters and a custom index for the `cell_ids` coordinate (notice how the coordinate name is displayed in bold), which will allow us to perform grid-aware operations.\n",
     "\n",
     "````{important}\n",
     "For this to work, the dataset has to have a coordinate called `cell_ids`, and it also has to have the `grid_name` and `level` attributes.\n",
     "\n",
-    "The `grid_name` refers to the short name of the grid, while `level` refers to the grid hierarchical level (the `h3` libraries call this the \"resolution\", while `xdggs` will use \"level\" for all grids)\n",
+    "The `grid_name` refers to the short name of the grid, while `level` refers to the grid hierarchical level (the `h3` libraries call this the \"resolution\", while `xdggs` will use \"level\" for all grids).\n",
     "\n",
     "In this case, the attributes on `cell_ids` are:\n",
     "```python\n",
@@ -81,7 +89,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -91,14 +99,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "source": [
-    "## deriving data\n",
+    "## Deriving data\n",
     "\n",
     "With the grid object and the custom index, we can derive additional data from the cell ids.\n",
     "\n",
-    "### cell center coordinates\n",
+    "### Cell center coordinates\n",
     "\n",
     "For example, we can reconstruct the cell centers we dropped from the original dataset, using {py:meth}`xarray.Dataset.dggs.cell_centers`:"
    ]
@@ -106,7 +114,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -116,16 +124,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "source": [
-    "these are the same as the ones we dropped before:"
+    "These are the same as the ones we dropped before:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -138,7 +146,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -147,10 +155,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "11",
+   "id": "12",
    "metadata": {},
    "source": [
-    "### cell boundary polygons\n",
+    "### Cell boundary polygons\n",
     "\n",
     "Additionally, we can derive the cell boundary polygons as an array of {doc}`shapely:index` using {py:meth}`xarray.Dataset.dggs.cell_boundaries`:"
    ]
@@ -158,7 +166,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -168,10 +176,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "13",
+   "id": "14",
    "metadata": {},
    "source": [
-    "## plotting\n",
+    "## Plotting\n",
     "\n",
     "We can quickly visualize the data using {py:meth}`xarray.DataArray.dggs.explore`, which is powered by [lonboard](https://github.com/developmentseed/lonboard).\n",
     "\n",
@@ -183,7 +191,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/tutorials/h3.ipynb
+++ b/docs/tutorials/h3.ipynb
@@ -15,7 +15,7 @@
    "id": "1",
    "metadata": {},
    "source": [
-    "## Load libraries"
+    "## Import libraries"
    ]
   },
   {

--- a/docs/tutorials/healpix.ipynb
+++ b/docs/tutorials/healpix.ipynb
@@ -136,7 +136,7 @@
    "id": "9",
    "metadata": {},
    "source": [
-    "these are the same as the ones we dropped before:"
+    "These are the same as the ones we dropped before:"
    ]
   },
   {

--- a/docs/tutorials/healpix.ipynb
+++ b/docs/tutorials/healpix.ipynb
@@ -77,7 +77,7 @@
    "source": [
     "After that, we can use {py:func}`xdggs.decode` to tell `xdggs` to interpret the cell ids.\n",
     "\n",
-    "This will create a grid object (see {py:attr}`xarray.Dataset.dggs.grid_info` and {py:class}`xdggs.HealpixInfo` for more information) containing the grid parameters and a custom index for the `cell_ids` coordinate (notice how the coordinate name is displayed in bold?), which will allow us to perform grid-aware operations.\n",
+    "This will create a grid object (see {py:attr}`xarray.Dataset.dggs.grid_info` and {py:class}`xdggs.HealpixInfo` for more information) containing the grid parameters and a custom index for the `cell_ids` coordinate (notice how the coordinate name is displayed in bold), which will allow us to perform grid-aware operations.\n",
     "\n",
     "````{important}\n",
     "For this to work, the dataset has to have a coordinate called `cell_ids`, and it also has to have the `grid_name`, `level` and `indexing_scheme` attributes.\n",

--- a/docs/tutorials/healpix.ipynb
+++ b/docs/tutorials/healpix.ipynb
@@ -1,9 +1,35 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "# Working with Healpix data\n",
+    "\n",
+    "Healpix has been used in cosmology for more than 20 years. See https://healpix.jpl.nasa.gov/html/intro.htm for more information.\n",
+    "\n",
+    "Healpix divides the sphere into sperical rectangles (\"pixels\") of equal size, starting with 12 \"base pixels\". Each of these \"base pixels\" is then further subdivided into 4 equally sized rectangles. The number of subdivisions is called \"order\", while the total number of rectangles within a \"base pixel\" is called \"nside\" (the relation between both is {math}`n_{\\mathrm{side}} = 2^{\\mathrm{order}}`).\n",
+    "\n",
+    "There are two major ways of numbering the \"pixels\" (the \"indexing scheme\"):\n",
+    "- `\"ring\"`, which assigns IDs to pixels based on the latitude rings they are on, such that pixels on the same latitude will have IDs close to each other.\n",
+    "- `\"nested\"`, which assigns IDs based on the pixel hierarchy, such that pixels within the same parent pixel have IDs close to each other.\n",
+    "\n",
+    "(Some Healpix libraries use the boolean `nest` to indicate the indexing scheme)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
+    "## Load libraries"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -16,28 +42,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1",
+   "id": "3",
    "metadata": {},
    "source": [
-    "# Working with Healpix data\n",
-    "\n",
-    "Healpix has been used in cosmology for more than 20 years. See https://healpix.jpl.nasa.gov/html/intro.htm for more information.\n",
-    "\n",
-    "Healpix divides the sphere into sperical rectangles (\"pixels\") of equal size, starting with 12 \"base pixels\". Each of these \"base pixels\" is then further subdivided into 4 equally sized rectangles. The number of subdivisions is called \"order\", while the total number of rectangles within a \"base pixel\" is called \"nside\" (the relation between both is {math}`n_{\\mathrm{side}} = 2^{\\mathrm{order}}`).\n",
-    "\n",
-    "There is two major ways of numbering the \"pixels\" (the \"indexing scheme\"):\n",
-    "- `\"ring\"`, which assigns IDs to pixels based on the latitude rings they are on, such that pixels on the same latitude will have IDs close to each other.\n",
-    "- `\"nested\"`, which assigns IDs based on the pixel hierarchy, such that pixels within the same parent pixel have IDs close to each other.\n",
-    "\n",
-    "(Some Healpix libraries use the boolean `nest` to indicate the indexing scheme)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "2",
-   "metadata": {},
-   "source": [
-    "## initialization\n",
+    "## Initialization\n",
     "\n",
     "To initialize, we first have to open the dataset. Here we'll use `xarray`'s `air_temperature` tutorial dataset, which was interpolated to the healpix grid.\n",
     "\n",
@@ -53,7 +61,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -64,7 +72,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "source": [
     "After that, we can use {py:func}`xdggs.decode` to tell `xdggs` to interpret the cell ids.\n",
@@ -90,7 +98,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -100,14 +108,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "source": [
-    "## deriving data\n",
+    "## Deriving data\n",
     "\n",
     "With the grid object and the custom index, we can derive additional data from the cell ids.\n",
     "\n",
-    "### cell center coordinates\n",
+    "### Cell center coordinates\n",
     "\n",
     "For example, we can reconstruct the cell centers we dropped from the original dataset, using {py:meth}`xarray.Dataset.dggs.cell_centers`:"
    ]
@@ -115,7 +123,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -125,7 +133,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "source": [
     "these are the same as the ones we dropped before:"
@@ -134,7 +142,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -147,7 +155,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -156,10 +164,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "11",
+   "id": "12",
    "metadata": {},
    "source": [
-    "### cell boundary polygons\n",
+    "### Cell boundary polygons\n",
     "\n",
     "Additionally, we can derive the cell boundary polygons as an array of {doc}`shapely:index` using {py:meth}`xarray.Dataset.dggs.cell_boundaries`:"
    ]
@@ -167,7 +175,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -177,10 +185,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "13",
+   "id": "14",
    "metadata": {},
    "source": [
-    "## plotting\n",
+    "## Plotting\n",
     "\n",
     "We can quickly visualize the data using {py:meth}`xarray.DataArray.dggs.explore`, which is powered by [lonboard](https://github.com/developmentseed/lonboard).\n",
     "\n",
@@ -192,7 +200,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/tutorials/healpix.ipynb
+++ b/docs/tutorials/healpix.ipynb
@@ -23,7 +23,7 @@
    "id": "1",
    "metadata": {},
    "source": [
-    "## Load libraries"
+    "## Import libraries"
    ]
   },
   {


### PR DESCRIPTION
The PR fixes mainly heading levels in notebooks. Other changes:

- Add a new section to load/import libraries
- Capitalise all section names
- Remove question mark in the sentence indicating coordinates are in bold.
- Fix minor typos