### PR TITLE
lint / format hooks for `pyproject.toml`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,17 @@ repos:
     hooks:
       - id: prettier
         args: [--cache-location=.prettier_cache/cache]
+  - repo: https://github.com/ComPWA/taplo-pre-commit
+    rev: v0.9.3
+    hooks:
+      - id: taplo-format
+        args: [--option, array_auto_collapse=false]
+      - id: taplo-lint
+        args: [--no-schema]
+  - repo: https://github.com/abravalheri/validate-pyproject
+    rev: v0.23
+    hooks:
+      - id: validate-pyproject
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.7.2
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,8 +5,6 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-docstring-first
-      - id: check-yaml
-      - id: check-toml
   - repo: https://github.com/rbubley/mirrors-prettier
     rev: v3.3.3
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,30 +7,30 @@ fallback_version = "9999"
 
 [tool.setuptools.packages.find]
 include = [
-    "xdggs",
-    "xdggs.*",
+  "xdggs",
+  "xdggs.*",
 ]
 
 [project]
 name = "xdggs"
 dynamic = ["version"]
 authors = [
-    {name = "Benoît Bovy"},
-    {name = "Justus Magin"},
+  { name = "Benoît Bovy" },
+  { name = "Justus Magin" },
 ]
 maintainers = [
-    {name = "xdggs contributors"},
+  { name = "xdggs contributors" },
 ]
-license = {text = "Apache-2.0"}
+license = { text = "Apache-2.0" }
 description = "Xarray extension for DGGS"
 keywords = ["DGGS", "xarray", "GIS"]
 readme = "Readme.md"
 classifiers = [
-    "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: Apache Software License",
-    "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3",
-    "Topic :: Scientific/Engineering :: GIS",
+  "Intended Audience :: Science/Research",
+  "License :: OSI Approved :: Apache Software License",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python :: 3",
+  "Topic :: Scientific/Engineering :: GIS",
 ]
 requires-python = ">=3.10"
 dependencies = [
@@ -53,11 +53,11 @@ Repository = "https://github.com/xarray-contrib/xdggs"
 target-version = "py310"
 builtins = ["ellipsis"]
 exclude = [
-    ".git",
-    ".eggs",
-    "build",
-    "dist",
-    "__pycache__",
+  ".git",
+  ".eggs",
+  "build",
+  "dist",
+  "__pycache__",
 ]
 line-length = 100
 
@@ -66,29 +66,29 @@ line-length = 100
 # E501: line too long - let black worry about that
 # E731: do not assign a lambda expression, use a def
 ignore = [
-    "E402",
-    "E501",
-    "E731",
+  "E402",
+  "E501",
+  "E731",
 ]
 select = [
-    "F",  # Pyflakes
-    "E",  # Pycodestyle
-    "I",  # isort
-    "UP", # Pyupgrade
-    "TID", # flake8-tidy-imports
-    "W",
+  "F",   # Pyflakes
+  "E",   # Pycodestyle
+  "I",   # isort
+  "UP",  # Pyupgrade
+  "TID", # flake8-tidy-imports
+  "W",
 ]
 extend-safe-fixes = [
-    "TID252", # absolute imports
+  "TID252", # absolute imports
 ]
 fixable = ["I", "TID252"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["xdggs"]
-known-third-party=[
-    "xarray",
-    "healpy",
-    "h3ronpy",
+known-third-party = [
+  "xarray",
+  "healpy",
+  "h3ronpy",
 ]
 
 [tool.ruff.lint.flake8-tidy-imports]
@@ -105,5 +105,5 @@ exclude_lines = ["pragma: no cover", "if TYPE_CHECKING"]
 
 [tool.pytest.ini_options]
 filterwarnings = [
-    "error:::xdggs.*",
+  "error:::xdggs.*",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,9 @@ classifiers = [
   "License :: OSI Approved :: Apache Software License",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Topic :: Scientific/Engineering :: GIS",
 ]
 requires-python = ">=3.10"


### PR DESCRIPTION
This adds `taplo` (TOML) and `validate-pyproject` (`pyproject.toml`'s project structure) hooks and removes the basic language check hooks.