### PR TITLE
always use the latest stable version when releasing

### DIFF
--- a/.github/workflows/pypipublish.yml
+++ b/.github/workflows/pypipublish.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.x"
       - name: Install publish dependencies
         run: python -m pip install build
       - name: Build package

--- a/.github/workflows/pypipublish.yml
+++ b/.github/workflows/pypipublish.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up Python 3.9
+      - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.9"


### PR DESCRIPTION
The release workflow referenced python 3.9, which we don't support (and never have, I believe).