### PR TITLE
use `arrow` functions to extract cell coordinates

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,8 @@
 
 ## Bug fixes
 
+- use explicit `arrow` API to extract cell coordinates ({issue}`113`, {pull}`114`)
+
 ## Documentation
 
 ## Internal changes

--- a/docs/tutorials/h3.ipynb
+++ b/docs/tutorials/h3.ipynb
@@ -150,7 +150,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "xr.testing.assert_equal(derived_ds, original_ds)"
+    "xr.testing.assert_allclose(derived_ds, original_ds)"
    ]
   },
   {

--- a/xdggs/h3.py
+++ b/xdggs/h3.py
@@ -141,7 +141,10 @@ class H3Info(DGGSInfo):
         lat : array-like
             The latitude coordinate values of the grid cells in degree
         """
-        lat, lon = cells_to_coordinates(cell_ids, radians=False)
+        result = cells_to_coordinates(cell_ids, radians=False)
+
+        lon = result.column("lng").to_numpy()
+        lat = result.column("lat").to_numpy()
 
         return lon, lat
 


### PR DESCRIPTION
It seems the change to `arro3` exposed an issue with the way we extract coordinates from the resulting object (a `arrow` `ResultBatch` object). The exact failure is a bug in `arro3.core`, but we had been relying on implicit behavior, so the change to explicit behavior is a positive either way.

- [x] closes #113
- [x] User visible changes (including notable bug fixes) are documented in `changelog.md`