### PR TITLE
request write permissions for issues

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -53,6 +53,9 @@ jobs:
       matrix:
         python-version: ["3.12"]
 
+    permissions:
+      issues: write
+
     steps:
       - name: Clone repository
         uses: actions/checkout@v4


### PR DESCRIPTION
As it turns out, new repositories have the actions permissions set to read-only. That setting is also fairly coarse, it's either read-only or read-write (for *everything*).

To be a bit more granular, we can request just the write permissions for `issues` within the job.

- [x] follow-up to #113