### PR TITLE
allow specifying additional coords to include in the pixel inspection table

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,8 @@
 
 ## New features
 
+- allow adding additional coords to the cell inspection table in the map ({pull}`122`)
+
 ## Bug fixes
 
 - use explicit `arrow` API to extract cell coordinates ({issue}`113`, {pull}`114`)

--- a/xdggs/accessor.py
+++ b/xdggs/accessor.py
@@ -174,7 +174,7 @@ class DGGSAccessor:
             boundaries, coords={self._name: self.cell_ids}, dims=self.cell_ids.dims
         )
 
-    def explore(self, *, cmap="viridis", center=None, alpha=None):
+    def explore(self, *, cmap="viridis", center=None, alpha=None, coords=None):
         """interactively explore the data using `lonboard`
 
         Requires `lonboard`, `matplotlib`, and `arro3.core` to be installed.
@@ -187,6 +187,8 @@ class DGGSAccessor:
             If set, will use this as the center value of a diverging color map.
         alpha : float, optional
             If set, controls the transparency of the polygons.
+        coords : list of str, default: ["latitude", "longitude"]
+            Additional coordinates to contain in the table of contents.
 
         Returns
         -------
@@ -207,4 +209,5 @@ class DGGSAccessor:
             cmap=cmap,
             center=center,
             alpha=alpha,
+            coords=coords,
         )

--- a/xdggs/plotting.py
+++ b/xdggs/plotting.py
@@ -45,6 +45,7 @@ def explore(
     cmap="viridis",
     center=None,
     alpha=None,
+    coords=None,
 ):
     import lonboard
     from lonboard import SolidPolygonLayer
@@ -66,7 +67,7 @@ def explore(
     colormap = colormaps[cmap] if isinstance(cmap, str) else cmap
     colors = apply_continuous_cmap(normalized_data, colormap, alpha=alpha)
 
-    table = create_arrow_table(polygons, arr)
+    table = create_arrow_table(polygons, arr, coords=coords)
     layer = SolidPolygonLayer(table=table, filled=True, get_fill_color=colors)
 
     return lonboard.Map(layer)


### PR DESCRIPTION
I noticed that the example dataset would not get the geographic coordinates included in the pixel inspection table.

- [ ] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `changelog.md`