### PR TITLE
support plotting multi-dimensional data

### DIFF
--- a/xdggs/accessor.py
+++ b/xdggs/accessor.py
@@ -200,10 +200,8 @@ class DGGSAccessor:
         if isinstance(self._obj, xr.Dataset):
             raise ValueError("does not work with Dataset objects, yet")
 
-        cell_dim = self._obj[self._name].dims[0]
         return explore(
             self._obj,
-            cell_dim=cell_dim,
             cmap=cmap,
             center=center,
             alpha=alpha,

--- a/xdggs/plotting.py
+++ b/xdggs/plotting.py
@@ -58,9 +58,9 @@ def explore(
     from lonboard import SolidPolygonLayer
     from matplotlib import colormaps
 
-    if len(arr.dims) != 1 or cell_dim not in arr.dims:
+    if cell_dim not in arr.dims:
         raise ValueError(
-            f"exploration only works with a single dimension ('{cell_dim}')"
+            f"exploration plotting only works with a spatial dimension ('{cell_dim}')"
         )
 
     cell_ids = arr.dggs.coord.data

--- a/xdggs/plotting.py
+++ b/xdggs/plotting.py
@@ -39,6 +39,14 @@ def normalize(var, center=None):
     return normalizer(var.data)
 
 
+def colorize(var, *, center, colormap, alpha):
+    from lonboard.colormap import apply_continuous_cmap
+
+    normalized_data = normalize(var, center=center)
+
+    return apply_continuous_cmap(normalized_data, colormap, alpha=alpha)
+
+
 def explore(
     arr,
     cell_dim="cells",
@@ -48,7 +56,6 @@ def explore(
 ):
     import lonboard
     from lonboard import SolidPolygonLayer
-    from lonboard.colormap import apply_continuous_cmap
     from matplotlib import colormaps
 
     if len(arr.dims) != 1 or cell_dim not in arr.dims:
@@ -61,10 +68,8 @@ def explore(
 
     polygons = grid_info.cell_boundaries(cell_ids, backend="geoarrow")
 
-    normalized_data = normalize(arr.variable, center=center)
-
     colormap = colormaps[cmap] if isinstance(cmap, str) else cmap
-    colors = apply_continuous_cmap(normalized_data, colormap, alpha=alpha)
+    colors = colorize(arr.variable, center=center, alpha=alpha, colormap=colormap)
 
     table = create_arrow_table(polygons, arr)
     layer = SolidPolygonLayer(table=table, filled=True, get_fill_color=colors)

--- a/xdggs/plotting.py
+++ b/xdggs/plotting.py
@@ -49,7 +49,6 @@ def colorize(var, *, center, colormap, alpha):
 
 def explore(
     arr,
-    cell_dim="cells",
     cmap="viridis",
     center=None,
     alpha=None,
@@ -58,12 +57,16 @@ def explore(
     from lonboard import SolidPolygonLayer
     from matplotlib import colormaps
 
+    # guaranteed to be 1D
+    cell_id_coord = arr.dggs.coord
+    [cell_dim] = cell_id_coord.dims
+
     if cell_dim not in arr.dims:
         raise ValueError(
             f"exploration plotting only works with a spatial dimension ('{cell_dim}')"
         )
 
-    cell_ids = arr.dggs.coord.data
+    cell_ids = cell_id_coord.data
     grid_info = arr.dggs.grid_info
 
     polygons = grid_info.cell_boundaries(cell_ids, backend="geoarrow")


### PR DESCRIPTION
- [x] follow-up to #77
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `changelog.md`

This adds sliders to support the visualization of multi-dimensional data (developed during the remote sprint this morning with @ofk123 and @evenmm).

The remaining things to improve are:
- ~~a text box for fine control of the selected value (the slider is a bit short)~~ looks like this is not necessary, we can go step-by-step using the arrow keys
- label-based selection instead of index-based selection
- a decision on where to put the controls (they're below the map for now)
- change the pixel inspection table to include the newly selected values

Follow-up tasks:
- [ ] add an example to the [lonboard integration gallery](https://developmentseed.org/lonboard/latest/examples/#integrations)

For an example, try:

``` python
import xdggs

ds = xdggs.tutorial.open_dataset("air_temperature", "h3").load().dggs.decode()
ds["air"].dggs.explore(alpha=0.8)
```

cc @kylebarron