### PR TITLE
Added gh button + fixed myst_nb + doc contributor guide

### DIFF
--- a/ci/docs.yml
+++ b/ci/docs.yml
@@ -1,10 +1,11 @@
+name: xdggs-docs
 channels:
   - conda-forge
 dependencies:
   - python=3.12
   - sphinx
-  - myst-parser
   - myst-nb
+  - sphinx-autobuild
   - sphinx-book-theme
   - sphinx-autosummary-accessors
   - sphinx-copybutton

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,8 @@
 
 ### Documentation
 
+- Documentation Contributer Guide + Github Button ({pull}`137`)
+
 ### Internal changes
 
 ## 0.2.0 (2025-02-12)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,6 +19,12 @@ root_doc = "index"
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
+
+source_suffix = {
+    ".rst": "restructuredtext",
+    ".md": "myst-nb", #enables myst-nb support for plain md files
+}
+
 extensions = [
     "sphinx.ext.extlinks",
     "sphinx.ext.intersphinx",
@@ -29,6 +35,8 @@ extensions = [
     "IPython.sphinxext.ipython_console_highlighting",
     "sphinx_autosummary_accessors",
     "myst_nb",
+    "sphinx_design",
+    "sphinx_copybutton",
     "sphinxcontrib.bibtex",
 ]
 
@@ -44,6 +52,13 @@ templates_path = ["_templates", sphinx_autosummary_accessors.templates_path]
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ["_build", "directory"]
+
+## Github Buttons
+html_theme_options = {
+    "repository_url": "https://github.com/xarray-contrib/xdggs",
+    "use_repository_button": True,
+    "use_issues_button": True,
+}
 
 # -- autosummary / autodoc ---------------------------------------------------
 
@@ -106,6 +121,16 @@ intersphinx_mapping = {
 
 nb_execution_timeout = -1
 nb_execution_cache_path = "_build/myst-nb"
+
+# myst options ---------------------------------------------------------------
+myst_enable_extensions = [
+    "colon_fence",      # Enables ::: directive syntax
+    "deflist",
+    "html_admonition",
+    "html_image",
+    "replacements",
+    "substitution",
+]
 
 # -- sphinxcontrib-bibtex ----------------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ root_doc = "index"
 
 source_suffix = {
     ".rst": "restructuredtext",
-    ".md": "myst-nb", #enables myst-nb support for plain md files
+    ".md": "myst-nb",  # enables myst-nb support for plain md files
 }
 
 extensions = [
@@ -124,7 +124,7 @@ nb_execution_cache_path = "_build/myst-nb"
 
 # myst options ---------------------------------------------------------------
 myst_enable_extensions = [
-    "colon_fence",      # Enables ::: directive syntax
+    "colon_fence",  # Enables ::: directive syntax
     "deflist",
     "html_admonition",
     "html_image",

--- a/docs/contributor_guide/docs.md
+++ b/docs/contributor_guide/docs.md
@@ -1,0 +1,48 @@
+# Contribute to the Documentation
+
+## Building the docs locally
+Set up your local environment with either mamba or conda
+
+::::{tab-set}
+:::{tab-item} Mamba
+```shell
+mamba env create -f ci/docs.yml
+```
+:::
+
+:::{tab-item} Conda
+```shell
+conda env create -f ci/docs.yml
+```
+:::
+::::
+
+And build the documentation locally (all commands assume you are in the root repo directory)
+
+::::{tab-set}
+:::{tab-item} Automatically show changes
+```
+sphinx-autobuild docs docs/_build/html --open-browser
+```
+This will open a browser window that shows a live preview (meaning that changes you make to the configuration and content will be automatically updated and shown in the browser). 
+:::
+
+:::{tab-item} Build and open manually
+
+From the root repo diretory build the html
+
+```shell
+sphinx-build -b html docs docs/_build/html
+```
+
+and open it in a browser
+
+```
+open docs/_build/html/index.html    # macOS
+xdg-open docs/_build/html/index.html  # Linux
+start docs/_build/html/index.html  # Windows
+```
+
+You will have to repeat these steps when you make changes
+:::
+::::

--- a/docs/contributor_guide/docs.md
+++ b/docs/contributor_guide/docs.md
@@ -1,19 +1,24 @@
 # Contribute to the Documentation
 
 ## Building the docs locally
+
 Set up your local environment with either mamba or conda
 
 ::::{tab-set}
 :::{tab-item} Mamba
+
 ```shell
 mamba env create -f ci/docs.yml
 ```
+
 :::
 
 :::{tab-item} Conda
+
 ```shell
 conda env create -f ci/docs.yml
 ```
+
 :::
 ::::
 
@@ -21,10 +26,12 @@ And build the documentation locally (all commands assume you are in the root rep
 
 ::::{tab-set}
 :::{tab-item} Automatically show changes
+
 ```
 sphinx-autobuild docs docs/_build/html --open-browser
 ```
-This will open a browser window that shows a live preview (meaning that changes you make to the configuration and content will be automatically updated and shown in the browser). 
+
+This will open a browser window that shows a live preview (meaning that changes you make to the configuration and content will be automatically updated and shown in the browser).
 :::
 
 :::{tab-item} Build and open manually

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,6 +38,16 @@ API Reference <api>
 Publications <reference_guide/publications>
 ```
 
+```{toctree}
+---
+maxdepth: 3
+caption: Contributor Guide
+hidden: true
+---
+
+Contribute to the Documentation <contributor_guide/docs>
+```
+
 # Welcome to `xdggs`
 
 [![PyPI](https://img.shields.io/pypi/v/xdggs.svg?style=flat)](https://pypi.org/project/xdggs)


### PR DESCRIPTION
- [x] User visible changes (including notable bug fixes) are documented in `changelog.md`
- [x] New functions/methods are listed in `api.rst`


Hey folks, thanks for putting together this great package. I wanted to fix some inconsistencies in the docs, and found it a bit tough to build the docs locally. 

This PR does the following:
- Adds a "Contributors Guide" Section with a docs specific instruction how to develop locally (adding sphinx-autobuild to be able to get a 'live' preview when developing locally)
- Fixes some issues with myst-nb rendering (the old setup would not understand mystmd directives properly
- Adds a github button to the docs (I find these super helpful)