### PR TITLE
Remove black-jupyter hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,10 +26,6 @@ repos:
     hooks:
       - id: ruff
         args: [--fix]
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 25.1.0
-    hooks:
-      - id: black-jupyter
   - repo: https://github.com/keewis/blackdoc
     rev: v0.3.9
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,6 @@ repos:
     hooks:
       - id: blackdoc
         additional_dependencies: ["black==25.1.0"]
-      - id: blackdoc-autoupdate-black
   - repo: https://github.com/citation-file-format/cffconvert
     rev: b6045d78aac9e02b039703b030588d54d53262ac
     hooks:


### PR DESCRIPTION
Ruff now natively supports notebooks
