### PR TITLE
healpix moc index

### DIFF
--- a/xdggs/accessor.py
+++ b/xdggs/accessor.py
@@ -29,7 +29,9 @@ class DGGSAccessor:
         self._name = name
         self._index = index
 
-    def decode(self, grid_info=None, *, name="cell_ids") -> xr.Dataset | xr.DataArray:
+    def decode(
+        self, grid_info=None, *, name="cell_ids", index_kind="pandas"
+    ) -> xr.Dataset | xr.DataArray:
         """decode the DGGS cell ids
 
         Parameters
@@ -51,7 +53,9 @@ class DGGSAccessor:
         if isinstance(grid_info, dict):
             var.attrs = grid_info
 
-        return self._obj.drop_indexes(name, errors="ignore").set_xindex(name, DGGSIndex)
+        return self._obj.drop_indexes(name, errors="ignore").set_xindex(
+            name, DGGSIndex, index_kind=index_kind
+        )
 
     @property
     def index(self) -> DGGSIndex:

--- a/xdggs/h3.py
+++ b/xdggs/h3.py
@@ -223,6 +223,7 @@ class H3Index(DGGSIndex):
     ) -> "H3Index":
         _, var, dim = _extract_cell_id_variable(variables)
 
+        options.pop("index_kind", None)
         grid_info = H3Info.from_dict(var.attrs | options)
 
         return cls(var.data, dim, grid_info)


### PR DESCRIPTION
Note: This is a highly experimental PR (and a lot still has to be done for this to be usable)

This tries to use the `RangeMOCIndex` class from EOPF-DGGS/healpix-geo#31 instead of the standard pandas index.

In theory, this should allow opening and decoding datasets up to level 29 without having to keep the cell ids in memory (and quite possibly we can skip loading the cell ids if we see that we have $12 \cdot 4^{\mathrm{level}}$ cells).

The current state does not support `dask` (so the cell ids will still be kept in memory), but this is definitely something that will be added as the PR progresses – I still have to understand how the coordinate transform indexes work in xarray.

- [x] closes #143
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `changelog.md`
- [ ] New functions/methods are listed in `api.rst`

cc @benbovy