### PR TITLE
install from conda-forge

### DIFF
--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -14,7 +14,7 @@ dependencies:
   - geoarrow-pyarrow
   - lonboard
   - arro3-core
+  - cdshealpix
   - pip
   - pip:
       - h3ronpy
-      - cdshealpix


### PR DESCRIPTION
So far, we installed `h3ronpy` and `cdshealpix` from PyPI. However, these should now also be available for all relevant platforms on `conda-forge`, so we may want to try installing from there.