### PR TITLE
bump python versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
 
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
       - name: Clone repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
 
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - name: Clone repository

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,12 @@
 
 ### New features
 
+- officially support python 3.13 ({pull}`162`)
+
+### Breaking changes
+
+- drop support for python 3.10 ({pull}`162`)
+
 ### Bug fixes
 
 ### Documentation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,13 +30,12 @@ classifiers = [
   "License :: OSI Approved :: Apache Software License",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Topic :: Scientific/Engineering :: GIS",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
   "xarray",
   "cdshealpix",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Topic :: Scientific/Engineering :: GIS",
 ]
 requires-python = ">=3.10"

--- a/xdggs/tests/__init__.py
+++ b/xdggs/tests/__init__.py
@@ -1,3 +1,5 @@
+import warnings
+
 import geoarrow.pyarrow as ga
 import shapely
 
@@ -6,6 +8,8 @@ from xdggs.tests.matchers import (  # noqa: F401
     MatchResult,
     assert_exceptions_equal,
 )
+
+warnings.filterwarnings("ignore", message="numpy.ndarray size changed")
 
 
 def geoarrow_to_shapely(arr):


### PR DESCRIPTION
- [x] User visible changes (including notable bug fixes) are documented in `changelog.md`

This drops support for python 3.10 (following `xarray`) and starts testing python 3.13.