### PR TITLE
support alignment

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,8 @@
 
 ### New features
 
+- support for alignment between indexes with the same grid parameters ({pull}`166`)
+
 ### Bug fixes
 
 ### Documentation

--- a/xdggs/index.py
+++ b/xdggs/index.py
@@ -144,7 +144,7 @@ class DGGSIndex(Index):
         return self.grid_info.cell_boundaries(self.values())
 
     def zoom_to(self, level: int) -> np.ndarray:
-        return self._grid.zoom_to(self._pd_index.index.values, level=level)
+        return self._grid.zoom_to(self.values(), level=level)
 
     @property
     def grid_info(self) -> DGGSInfo:

--- a/xdggs/index.py
+++ b/xdggs/index.py
@@ -89,6 +89,16 @@ class DGGSIndex(Index):
     def values(self):
         return self._index.index.values
 
+    def equals(self, other: Index, **kwargs) -> bool:
+        if (
+            type(self) is not type(other)
+            or self._dim != other._dim
+            or self._grid != other._grid
+        ):
+            return False
+
+        return self._pd_index.equals(other._pd_index, **kwargs)
+
     def create_variables(
         self, variables: Mapping[Any, xr.Variable] | None = None
     ) -> dict[Hashable, xr.Variable]:

--- a/xdggs/index.py
+++ b/xdggs/index.py
@@ -97,7 +97,7 @@ class DGGSIndex(Index):
         ):
             return False
 
-        return self._pd_index.equals(other._pd_index, **kwargs)
+        return self._index.equals(other._index, **kwargs)
 
     def create_variables(
         self, variables: Mapping[Any, xr.Variable] | None = None
@@ -124,7 +124,7 @@ class DGGSIndex(Index):
                 "Alignment with different grid parameters is not supported."
             )
 
-        return self._replace(self._pd_index.join(other._pd_index, how=how))
+        return self._replace(self._index.join(other._index, how=how))
 
     def reindex_like(self, other: Self) -> dict[Hashable, Any]:
         if self.grid_info != other.grid_info:
@@ -132,7 +132,7 @@ class DGGSIndex(Index):
                 "Reindexing to different grid parameters is not supported."
             )
 
-        return self._pd_index.reindex_like(other._pd_index)
+        return self._index.reindex_like(other._index)
 
     def _replace(self, new_index: PandasIndex):
         raise NotImplementedError()

--- a/xdggs/tests/test_h3.py
+++ b/xdggs/tests/test_h3.py
@@ -313,3 +313,45 @@ def test_repr_inline(level, max_width):
     assert f"level={level}" in actual
     # ignore max_width for now
     # assert len(actual) <= max_width
+
+
+def test_join():
+    data1 = np.array(
+        [0x821987FFFFFFFFF, 0x822831FFFFFFFFF, 0x822837FFFFFFFFF, 0x82285FFFFFFFFFF]
+    )
+    data2 = np.array([0x821987FFFFFFFFF, 0x822837FFFFFFFFF, 0x82285FFFFFFFFFF])
+
+    dim = "cells"
+    grid_info = h3.H3Info(level=2)
+
+    index1 = h3.H3Index(data1, dim=dim, grid_info=grid_info)
+    index2 = h3.H3Index(data2, dim=dim, grid_info=grid_info)
+
+    actual = index1.join(index2, how="inner")
+    expected = h3.H3Index(data2, dim=dim, grid_info=grid_info)
+
+    assert actual._grid == expected._grid
+    assert actual._dim == expected._dim
+    assert np.all(actual._pd_index.index == expected._pd_index.index)
+
+
+def test_reindex_like():
+    grid = h3.H3Info(level=2)
+    index1 = h3.H3Index(
+        cell_ids=np.array([0x821987FFFFFFFFF, 0x822837FFFFFFFFF, 0x82285FFFFFFFFFF]),
+        dim="cells",
+        grid_info=grid,
+    )
+    index2 = h3.H3Index(
+        cell_ids=np.array(
+            [0x821987FFFFFFFFF, 0x822831FFFFFFFFF, 0x822837FFFFFFFFF, 0x82285FFFFFFFFFF]
+        ),
+        dim="cells",
+        grid_info=grid,
+    )
+
+    actual = index1.reindex_like(index2)
+
+    expected = {"cells": np.array([0, -1, 1, 2])}
+
+    np.testing.assert_equal(actual["cells"], expected["cells"])

--- a/xdggs/tests/test_h3.py
+++ b/xdggs/tests/test_h3.py
@@ -332,7 +332,7 @@ def test_join():
 
     assert actual._grid == expected._grid
     assert actual._dim == expected._dim
-    assert np.all(actual._pd_index.index == expected._pd_index.index)
+    assert np.all(actual._index.index == expected._index.index)
 
 
 def test_join_error():

--- a/xdggs/tests/test_h3.py
+++ b/xdggs/tests/test_h3.py
@@ -387,3 +387,36 @@ def test_reindex_like_error():
 
     with pytest.raises(ValueError, match="different grid parameters"):
         index1.reindex_like(index2)
+
+
+@pytest.mark.parametrize(
+    "variant", ("identical", "all-different", "dim", "grid-info", "values")
+)
+def test_equals(variant):
+    values = [
+        np.array([0x832833FFFFFFFFF, 0x832834FFFFFFFFF, 0x832835FFFFFFFFF]),
+        np.array([0x832831FFFFFFFFF, 0x832832FFFFFFFFF]),
+    ]
+    dims = ["cells", "zones"]
+    grid_info = [h3.H3Info(level=1), h3.H3Info(level=6)]
+
+    dim1 = dims[0]
+    values1 = values[0]
+    grid_info1 = grid_info[0]
+
+    variants = {
+        "identical": (dims[0], values[0], grid_info[0]),
+        "all-different": (dims[1], values[1], grid_info[1]),
+        "dim": (dims[1], values[0], grid_info[0]),
+        "grid-info": (dims[0], values[0], grid_info[1]),
+        "values": (dims[0], values[1], grid_info[0]),
+    }
+    expected_results = {"identical": True}
+
+    expected = expected_results.get(variant, False)
+    dim2, values2, grid_info2 = variants[variant]
+
+    index1 = h3.H3Index(values1, dim=dim1, grid_info=grid_info1)
+    index2 = h3.H3Index(values2, dim=dim2, grid_info=grid_info2)
+
+    assert index1.equals(index2) == expected

--- a/xdggs/tests/test_h3.py
+++ b/xdggs/tests/test_h3.py
@@ -335,6 +335,22 @@ def test_join():
     assert np.all(actual._pd_index.index == expected._pd_index.index)
 
 
+def test_join_error():
+    data1 = np.array([0x832833FFFFFFFFF, 0x832834FFFFFFFFF, 0x832835FFFFFFFFF])
+    data2 = np.array([0x832831FFFFFFFFF, 0x832832FFFFFFFFF])
+
+    dim = "cells"
+
+    grid_info1 = h3.H3Info(level=1)
+    grid_info2 = h3.H3Info(level=6)
+
+    index1 = h3.H3Index(data1, dim=dim, grid_info=grid_info1)
+    index2 = h3.H3Index(data2, dim=dim, grid_info=grid_info2)
+
+    with pytest.raises(ValueError, match="different grid parameters"):
+        index1.join(index2, how="inner")
+
+
 def test_reindex_like():
     grid = h3.H3Info(level=2)
     index1 = h3.H3Index(
@@ -355,3 +371,19 @@ def test_reindex_like():
     expected = {"cells": np.array([0, -1, 1, 2])}
 
     np.testing.assert_equal(actual["cells"], expected["cells"])
+
+
+def test_reindex_like_error():
+    data1 = np.array([0x832833FFFFFFFFF, 0x832834FFFFFFFFF, 0x832835FFFFFFFFF])
+    data2 = np.array([0x832831FFFFFFFFF, 0x832832FFFFFFFFF])
+
+    dim = "cells"
+
+    grid_info1 = h3.H3Info(level=1)
+    grid_info2 = h3.H3Info(level=6)
+
+    index1 = h3.H3Index(data1, dim=dim, grid_info=grid_info1)
+    index2 = h3.H3Index(data2, dim=dim, grid_info=grid_info2)
+
+    with pytest.raises(ValueError, match="different grid parameters"):
+        index1.reindex_like(index2)

--- a/xdggs/tests/test_healpix.py
+++ b/xdggs/tests/test_healpix.py
@@ -901,7 +901,7 @@ def test_join():
 
     assert actual._grid == expected._grid
     assert actual._dim == expected._dim
-    assert np.all(actual._pd_index.index == expected._pd_index.index)
+    assert np.all(actual._index.index == expected._index.index)
 
 
 def test_join_error():

--- a/xdggs/tests/test_healpix.py
+++ b/xdggs/tests/test_healpix.py
@@ -954,3 +954,33 @@ def test_reindex_like_error():
 
     with pytest.raises(ValueError, match="different grid parameters"):
         index1.reindex_like(index2)
+
+
+@pytest.mark.parametrize(
+    "variant", ("identical", "all-different", "dim", "grid-info", "values")
+)
+def test_equals(variant):
+    values = [np.array([0, 7], dtype="uint64"), np.array([0, 5, 7], dtype="uint64")]
+    dims = ["cells", "zones"]
+    grid_info = [healpix.HealpixInfo(level=1), healpix.HealpixInfo(level=6)]
+
+    dim1 = dims[0]
+    values1 = values[0]
+    grid_info1 = grid_info[0]
+
+    variants = {
+        "identical": (dims[0], values[0], grid_info[0]),
+        "all-different": (dims[1], values[1], grid_info[1]),
+        "dim": (dims[1], values[0], grid_info[0]),
+        "grid-info": (dims[0], values[0], grid_info[1]),
+        "values": (dims[0], values[1], grid_info[0]),
+    }
+    expected_results = {"identical": True}
+
+    expected = expected_results.get(variant, False)
+    dim2, values2, grid_info2 = variants[variant]
+
+    index1 = healpix.HealpixIndex(values1, dim=dim1, grid_info=grid_info1)
+    index2 = healpix.HealpixIndex(values2, dim=dim2, grid_info=grid_info2)
+
+    assert index1.equals(index2) == expected

--- a/xdggs/tests/test_healpix.py
+++ b/xdggs/tests/test_healpix.py
@@ -884,3 +884,41 @@ class TestHealpixMocIndex:
 
         with pytest.raises(ValueError, match="Cell ids can't be negative"):
             index.sel({"cell_ids": indexer})
+
+
+def test_join():
+    data1 = np.array([0, 5, 7, 9], dtype="uint64")
+    data2 = np.array([0, 7])
+
+    dim = "cells"
+    grid_info = healpix.HealpixInfo(level=2)
+
+    index1 = healpix.HealpixIndex(data1, dim=dim, grid_info=grid_info)
+    index2 = healpix.HealpixIndex(data2, dim=dim, grid_info=grid_info)
+
+    actual = index1.join(index2, how="inner")
+    expected = healpix.HealpixIndex(data2, dim=dim, grid_info=grid_info)
+
+    assert actual._grid == expected._grid
+    assert actual._dim == expected._dim
+    assert np.all(actual._pd_index.index == expected._pd_index.index)
+
+
+def test_reindex_like():
+    grid = healpix.HealpixInfo(level=2)
+    index1 = healpix.HealpixIndex(
+        cell_ids=np.array([0, 7]),
+        dim="cells",
+        grid_info=grid,
+    )
+    index2 = healpix.HealpixIndex(
+        cell_ids=np.array([0, 5, 7, 9]),
+        dim="cells",
+        grid_info=grid,
+    )
+
+    actual = index1.reindex_like(index2)
+
+    expected = {"cells": np.array([0, -1, 1, -1])}
+
+    np.testing.assert_equal(actual["cells"], expected["cells"])

--- a/xdggs/tests/test_healpix.py
+++ b/xdggs/tests/test_healpix.py
@@ -904,6 +904,22 @@ def test_join():
     assert np.all(actual._pd_index.index == expected._pd_index.index)
 
 
+def test_join_error():
+    data1 = np.array([0, 7], dtype="uint64")
+    data2 = np.array([5, 7, 9], dtype="uint64")
+
+    dim = "cells"
+
+    grid_info1 = healpix.HealpixInfo(level=1)
+    grid_info2 = healpix.HealpixInfo(level=6)
+
+    index1 = healpix.HealpixIndex(data1, dim=dim, grid_info=grid_info1)
+    index2 = healpix.HealpixIndex(data2, dim=dim, grid_info=grid_info2)
+
+    with pytest.raises(ValueError, match="different grid parameters"):
+        index1.join(index2, how="inner")
+
+
 def test_reindex_like():
     grid = healpix.HealpixInfo(level=2)
     index1 = healpix.HealpixIndex(
@@ -922,3 +938,19 @@ def test_reindex_like():
     expected = {"cells": np.array([0, -1, 1, -1])}
 
     np.testing.assert_equal(actual["cells"], expected["cells"])
+
+
+def test_reindex_like_error():
+    data1 = np.array([0, 7], dtype="uint64")
+    data2 = np.array([0, 5, 7], dtype="uint64")
+
+    dim = "cells"
+
+    grid_info1 = healpix.HealpixInfo(level=1)
+    grid_info2 = healpix.HealpixInfo(level=6)
+
+    index1 = healpix.HealpixIndex(data1, dim=dim, grid_info=grid_info1)
+    index2 = healpix.HealpixIndex(data2, dim=dim, grid_info=grid_info2)
+
+    with pytest.raises(ValueError, match="different grid parameters"):
+        index1.reindex_like(index2)


### PR DESCRIPTION
- [x] towards #7
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `changelog.md`

For now this is just alignment between datasets on the same refinement level, and most of the work is done by forwarding to the wrapped index.