### PR TITLE
remove compat code for `python<3.11`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ dependencies = [
   "xarray",
   "cdshealpix",
   "h3ronpy",
-  "typing-extensions",
   "lonboard>=0.9.3",
   "pyproj>=3.3",
   "matplotlib",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ hooks.vcs.version-file = "xdggs/_version.py"
 only-include = ["xdggs"]
 
 [tool.ruff]
-target-version = "py310"
+target-version = "py311"
 builtins = ["ellipsis"]
 exclude = [
   ".git",

--- a/xdggs/grid.py
+++ b/xdggs/grid.py
@@ -1,13 +1,8 @@
 import operator
 from dataclasses import dataclass
-from typing import Any, TypeVar
+from typing import Any, Self, TypeVar
 
 from xdggs.itertools import groupby, identity
-
-try:
-    from typing import Self
-except ImportError:  # pragma: no cover
-    from typing_extensions import Self
 
 try:
     ExceptionGroup

--- a/xdggs/grid.py
+++ b/xdggs/grid.py
@@ -4,11 +4,6 @@ from typing import Any, Self, TypeVar
 
 from xdggs.itertools import groupby, identity
 
-try:
-    ExceptionGroup
-except NameError:  # pragma: no cover
-    from exceptiongroup import ExceptionGroup
-
 T = TypeVar("T")
 
 

--- a/xdggs/h3.py
+++ b/xdggs/h3.py
@@ -1,12 +1,7 @@
 import json
 from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any, ClassVar
-
-try:
-    from typing import Self
-except ImportError:  # pragma: no cover
-    from typing_extensions import Self
+from typing import Any, ClassVar, Self
 
 import numpy as np
 import xarray as xr

--- a/xdggs/healpix.py
+++ b/xdggs/healpix.py
@@ -1,12 +1,7 @@
 import json
 from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any, ClassVar, Literal, TypeVar
-
-try:
-    from typing import Self
-except ImportError:  # pragma: no cover
-    from typing_extensions import Self
+from typing import Any, ClassVar, Literal, Self, TypeVar
 
 import cdshealpix.nested
 import cdshealpix.ring

--- a/xdggs/tests/matchers.py
+++ b/xdggs/tests/matchers.py
@@ -2,11 +2,6 @@ import enum
 import re
 from dataclasses import dataclass, field
 
-try:
-    ExceptionGroup
-except NameError:
-    from exceptiongroup import BaseExceptionGroup, ExceptionGroup
-
 
 class MatchResult(enum.Enum):
     match = 0

--- a/xdggs/tests/test_healpix.py
+++ b/xdggs/tests/test_healpix.py
@@ -14,11 +14,6 @@ from xarray.core.indexes import PandasIndex
 from xdggs import healpix
 from xdggs.tests import assert_exceptions_equal, geoarrow_to_shapely
 
-try:
-    ExceptionGroup
-except NameError:  # pragma: no cover
-    from exceptiongroup import ExceptionGroup
-
 
 # namespace class
 class strategies:

--- a/xdggs/tests/test_matchers.py
+++ b/xdggs/tests/test_matchers.py
@@ -2,11 +2,6 @@ import pytest
 
 from xdggs.tests import matchers
 
-try:
-    ExceptionGroup
-except NameError:  # pragma: no cover
-    from exceptiongroup import ExceptionGroup
-
 
 class TestMatch:
     def test_construct_simple(self):


### PR DESCRIPTION
We've dropped `python=3.10` in #162, so now we can remove a bunch of compat code.