### PR TITLE
ensure that decoding does not modify the input dataset

### DIFF
--- a/xdggs/conventions/zarr.py
+++ b/xdggs/conventions/zarr.py
@@ -1,3 +1,4 @@
+import copy
 from collections.abc import Hashable
 from typing import Any, Literal
 
@@ -88,7 +89,7 @@ class Zarr(Convention):
                     " object to the `grid_info` parameter."
                 )
         # copy to avoid mutating
-        metadata = dict(grid_info)
+        metadata = copy.deepcopy(grid_info)
 
         # information:
         # - "name" is the grid name
@@ -127,7 +128,9 @@ class Zarr(Convention):
         index_cls = GRID_REGISTRY[grid_name]
         index = index_cls.from_variables({name: var}, options=index_options)
 
-        new_ds = ds.copy(deep=False).assign_coords(xr.Coordinates.from_xindex(index))
+        new_ds = ds.assign_coords(xr.Coordinates.from_xindex(index)).assign_attrs(
+            copy.deepcopy(ds.attrs)
+        )
         new_ds.attrs.pop("dggs", None)
         if convention_index is not None:
             zarr_conventions = new_ds.attrs.get("zarr_conventions", [])

--- a/xdggs/conventions/zarr.py
+++ b/xdggs/conventions/zarr.py
@@ -131,12 +131,14 @@ class Zarr(Convention):
         new_ds = ds.assign_coords(xr.Coordinates.from_xindex(index)).assign_attrs(
             copy.deepcopy(ds.attrs)
         )
+        # remove redundant attrs
         new_ds.attrs.pop("dggs", None)
         if convention_index is not None:
             zarr_conventions = new_ds.attrs.get("zarr_conventions", [])
             del zarr_conventions[convention_index]
             if not zarr_conventions:
                 del new_ds.attrs["zarr_conventions"]
+
         return new_ds
 
     def encode(

--- a/xdggs/tests/test_conventions.py
+++ b/xdggs/tests/test_conventions.py
@@ -213,12 +213,16 @@ class TestZarrConvention:
         expected = xr.Coordinates.from_xindex(index).to_dataset()
 
         obj = xr.Dataset(coords={name: var}, attrs=metadata)
+        orig = obj.copy(deep=True)
         actual = convention.decode(
             obj,
             grid_info=None,
             name=name,
             index_options={},
         )
+        # should not modify the original dataset
+        xr.testing.assert_identical(obj, orig)
+
         print(obj, actual, expected)
         xr.testing.assert_identical(actual, expected)
         assert_indexes_equal(actual[name].xindexes, expected[name].xindexes)


### PR DESCRIPTION
This was a pretty annoying bug in the `zarr` convention implementation.