### PR TITLE
rewrite the explore widget into a more modular set of widgets

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,7 @@
 
 - Do not mutate the input dataset when decoding ({pull}`226`)
 - Properly decode ellipsoids for the CF convention ({pull}`228`)
+- Rewrite the map widgets using `anywidget` ({pull}`248`)
 
 ## 0.6.0 (2026-02-05)
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -110,6 +110,7 @@ h5netcdf = ">=1.7.3"
 zarr = ">=3.1.5"
 cf-xarray = ">=0.11.1"
 marimo = ">=0.23.16,<0.24"
+watchfiles = ">=1.1.0"
 
 [environments]
 nightly = { features = [

--- a/pixi.toml
+++ b/pixi.toml
@@ -19,7 +19,7 @@ pyproj = ">=3.3"
 matplotlib-base = ">=3.10.5"
 arro3-core = ">=0.4.0"
 pooch = ">=1.8.2"
-healpix-geo = ">=0.0.9"
+healpix-geo = ">=0.2.1"
 
 [feature.tests.dependencies]
 pytest = "*"

--- a/pixi.toml
+++ b/pixi.toml
@@ -109,6 +109,7 @@ jupyterlab-myst = ">=2.4.2"
 h5netcdf = ">=1.7.3"
 zarr = ">=3.1.5"
 cf-xarray = ">=0.11.1"
+marimo = ">=0.23.16,<0.24"
 
 [environments]
 nightly = { features = [

--- a/pixi.toml
+++ b/pixi.toml
@@ -50,11 +50,11 @@ pandas = "*"
 pyarrow = "*"
 h3ronpy = { git = "git+https://github.com/nmandery/h3ronpy.git", subdirectory = "h3ronpy" }
 cdshealpix = { git = "git+https://github.com/cds-astro/cds-healpix-python.git" }
-healpix-geo = { git = "git+https://github.com/eopf-dggs/healpix-geo.git", subdirectory = "python/healpix-geo" }
+healpix-geo = { git = "git+https://github.com/grid4earth/healpix-geo.git", subdirectory = "python/healpix-geo" }
 astropy = { git = "git+https://github.com/astropy/astropy.git" }
+lonboard = { git = "git+https://github.com/developmentseed/lonboard.git" }
 
 [feature.nightly.target.unix.dependencies]
-lonboard = ">=0.11.1"
 pyproj = ">=3.7.2"
 matplotlib-base = ">=3.10.5"
 arro3-core = ">=0.6.1"

--- a/pixi.toml
+++ b/pixi.toml
@@ -20,6 +20,7 @@ matplotlib-base = ">=3.10.5"
 arro3-core = ">=0.4.0"
 pooch = ">=1.8.2"
 healpix-geo = ">=0.2.1"
+anywidget = ">=0.11.0"
 
 [feature.tests.dependencies]
 pytest = "*"

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,9 +1,10 @@
 [workspace]
 channels = ["conda-forge"]
-platforms = ["linux-64", "win-64", "osx-arm64"]
-
-[system-requirements]
-libc = { family = "glibc", version = "2.34" }
+platforms = [
+  "linux-64",
+  "win-64",
+  "osx-arm64",
+]
 
 [pypi-dependencies]
 xdggs = { path = ".", editable = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
   "matplotlib",
   "arro3-core>=0.4.0",
   "pooch",
+  "anywidget>=0.11",
 ]
 dynamic = ["version"]
 

--- a/xdggs/plotting/__init__.py
+++ b/xdggs/plotting/__init__.py
@@ -159,7 +159,10 @@ def explore(
 
     label = extract_label(arr)
 
-    # dimension_coordinates = {dim: format_labels(obj[dim].data) for dim in obj.dims}
+    # TODO: look up single-dimensional indexes along the dimension
+    dimension_coordinates = {
+        dim: format_labels(obj[dim].data) for dim in obj.dims if dim in obj.coords
+    }
 
     normalized_data, stats = normalize(initial_arr, params=colorize_params)
     colors = colorize(normalized_data, colorize_params)
@@ -176,6 +179,7 @@ def explore(
             dim: size - 1 for dim, size in obj.sizes.items() if dim != cell_dim
         },
         dimension_available=available_dims(arr.dims, set(obj.dims) - {cell_dim}),
+        dimension_labels=dimension_coordinates,
     )
     colorbar = Colorbar(
         colors=extract_colors(colorize_params.cmap), label=label, **stats

--- a/xdggs/plotting/__init__.py
+++ b/xdggs/plotting/__init__.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass
 from functools import partial
 from typing import TYPE_CHECKING, Any
 
-import ipywidgets
 import numpy as np
 import xarray as xr
 
@@ -16,6 +15,8 @@ from xdggs.plotting.colorize import (
     extract_colors,
     normalize,
 )
+from xdggs.plotting.control import ControlPanel
+from xdggs.plotting.dimensions import DimensionSliders
 from xdggs.plotting.map import MapWithControls
 from xdggs.plotting.variables import construct_variable_chooser
 
@@ -56,25 +57,18 @@ class Container:
     colorize_params: ColorizeParameters
 
 
-def on_slider_change(change, changed_dim, container):
+def on_slider_change(change, container):
     if isinstance(container.obj, xr.DataArray):
         arr = container.obj
     else:
-        name = container.widget.variables.value
+        name = container.widget.control.variable_chooser.value
         arr = container.obj[name]
 
-    if changed_dim not in arr.dims:
+    available = change["owner"].dimension_available
+    indexers = {dim: v for dim, v in change["new"].items() if available[dim]}
+    if not indexers:
         # should not happen
         return
-
-    indexers = {
-        dim: slider.value
-        for dim, slider in container.widget.sliders.items()
-        if dim in arr.dims and dim != changed_dim
-    } | {changed_dim: change["new"]}
-
-    for dim, slider in container.widget.sliders.items():
-        slider.disabled = dim not in arr.dims
 
     new_slice = arr.isel(indexers)
     normalized, stats = normalize(new_slice, container.colorize_params)
@@ -83,7 +77,7 @@ def on_slider_change(change, changed_dim, container):
     layer = container.layer
     layer.get_fill_color = colors
 
-    colorbar = container.widget.colorbar
+    colorbar = container.widget.control.colorbar
     for name, value in stats.items():
         setattr(colorbar, name, value)
 
@@ -96,23 +90,20 @@ def on_variable_change(change, container):
     name = change["new"]
     arr = container.obj[name]
 
-    indexers = {
-        dim: slider.value
-        for dim, slider in container.widget.sliders.items()
-        if dim in arr.dims
-    }
+    sliders = container.widget.control.dimension_sliders
+    indexers = sliders.dimension_values
 
     new_slice = arr.isel(indexers)
     normalized, stats = normalize(new_slice, container.colorize_params)
     colors = colorize(normalized, container.colorize_params)
 
-    for dim, slider in container.widget.sliders.items():
-        slider.disabled = dim not in arr.dims
+    available = {dim: dim in arr.dims for dim in container.obj.dims}
+    sliders.dimension_available = available
 
     layer = container.layer
     layer.get_fill_color = colors
 
-    colorbar = container.widget.colorbar
+    colorbar = container.widget.control.colorbar
     for name, value in stats.items():
         setattr(colorbar, name, value)
     colorbar.label = extract_label(arr)
@@ -147,7 +138,7 @@ def explore(
     polygons = grid_info.cell_boundaries(cell_ids, backend="geoarrow")
 
     variable_chooser = construct_variable_chooser(obj)
-    if isinstance(obj, xr.Dataset) and not variable_chooser.options:
+    if isinstance(obj, xr.Dataset) and not variable_chooser.variables:
         raise ValueError("cannot find spatial variables")
 
     if isinstance(obj, xr.Dataset):
@@ -161,7 +152,7 @@ def explore(
 
     label = extract_label(arr)
 
-    dimension_coordinates = {dim: format_labels(obj[dim].data) for dim in obj.dims}
+    # dimension_coordinates = {dim: format_labels(obj[dim].data) for dim in obj.dims}
 
     normalized_data, stats = normalize(initial_arr, params=colorize_params)
     colors = colorize(normalized_data, colorize_params)
@@ -173,38 +164,29 @@ def explore(
 
     map_ = lonboard.Map(layer, **map_kwargs)
 
-    sliders = {
-        dim: ipywidgets.IntSlider(
-            min=0,
-            max=obj.sizes[dim] - 1,
-            disabled=dim not in arr.dims,
-            readout=False,
-        )
-        for dim in obj.dims
-        if dim != cell_dim
-    }
-
+    dimension_sliders = DimensionSliders(
+        dimensions={dim: size - 1 for dim, size in obj.sizes.items() if dim != cell_dim}
+    )
     colorbar = Colorbar(
         colors=extract_colors(colorize_params.cmap), label=label, **stats
+    )
+    controls = ControlPanel(
+        variable_chooser=variable_chooser,
+        dimension_sliders=dimension_sliders,
+        colorbar=colorbar,
     )
 
     map_widget = MapWithControls(
         map=map_,
-        variables=variable_chooser,
-        dimensions=dimension_indices,
-        coordinates=dimension_coordinates,
-        sliders=sliders,
-        colorbar=colorbar,
+        control=controls,
     )
 
     container = Container(map_widget, layer, obj, colorize_params)
 
     # event handling
-    for dim, slider in sliders.items():
-        slider.observe(
-            partial(on_slider_change, changed_dim=dim, container=container),
-            names="value",
-        )
+    dimension_sliders.observe(
+        partial(on_slider_change, container=container), "dimension_values"
+    )
 
     variable_chooser.observe(
         partial(on_variable_change, container=container), names="value"

--- a/xdggs/plotting/__init__.py
+++ b/xdggs/plotting/__init__.py
@@ -49,6 +49,10 @@ def extract_label(arr):
     return label
 
 
+def available_dims(arr_dims, all_dims):
+    return {dim: dim in arr_dims for dim in all_dims}
+
+
 @dataclass
 class Container:
     widget: MapWithControls
@@ -66,6 +70,7 @@ def on_slider_change(change, container):
 
     available = change["owner"].dimension_available
     indexers = {dim: v for dim, v in change["new"].items() if available[dim]}
+
     if not indexers:
         # should not happen
         return
@@ -91,14 +96,16 @@ def on_variable_change(change, container):
     arr = container.obj[name]
 
     sliders = container.widget.control.dimension_sliders
-    indexers = sliders.dimension_values
+    sliders.dimension_available = available_dims(arr.dims, sliders.dimensions)
+    indexers = {
+        dim: v
+        for dim, v in sliders.dimension_values.items()
+        if sliders.dimension_available[dim]
+    }
 
     new_slice = arr.isel(indexers)
     normalized, stats = normalize(new_slice, container.colorize_params)
     colors = colorize(normalized, container.colorize_params)
-
-    available = {dim: dim in arr.dims for dim in container.obj.dims}
-    sliders.dimension_available = available
 
     layer = container.layer
     layer.get_fill_color = colors
@@ -165,7 +172,10 @@ def explore(
     map_ = lonboard.Map(layer, **map_kwargs)
 
     dimension_sliders = DimensionSliders(
-        dimensions={dim: size - 1 for dim, size in obj.sizes.items() if dim != cell_dim}
+        dimensions={
+            dim: size - 1 for dim, size in obj.sizes.items() if dim != cell_dim
+        },
+        dimension_available=available_dims(arr.dims, set(obj.dims) - {cell_dim}),
     )
     colorbar = Colorbar(
         colors=extract_colors(colorize_params.cmap), label=label, **stats

--- a/xdggs/plotting/colorbar.js
+++ b/xdggs/plotting/colorbar.js
@@ -89,33 +89,26 @@ function render({ model, el }) {
     .append("svg")
     .attr("width", width)
     .attr("height", 400);
-  // axis label
-  const label = svg
-    .append("text")
-    .attr("text-anchor", "middle")
-    .attr("x", width / 2)
-    .attr("y", marginTop + 5)
-    .text(model.get("label"));
-  const labelHeight = label.node().getBBox().height;
-
   // ramp
   let image = svg
     .append("g")
-    .attr(
-      "transform",
-      `translate(${marginLeft + 1}, ${marginTop + labelHeight + labelSpacer})`,
-    )
+    .attr("transform", `translate(${marginLeft + 1}, ${marginTop})`)
     .call((image) => draw_ramp(image, colors, widget_width, rampHeight));
 
   // ticks and tick labels
   const xaxis = svg
     .append("g")
-    .attr(
-      "transform",
-      `translate(0,${marginTop + labelHeight + labelSpacer + rampHeight})`,
-    )
+    .attr("transform", `translate(0,${marginTop + rampHeight})`)
     .call(d3.axisBottom(x));
   const axisHeight = xaxis.node().getBBox().height;
+  // axis label
+  const label = svg
+    .append("text")
+    .attr("text-anchor", "middle")
+    .attr("x", width / 2)
+    .attr("y", marginTop + rampHeight + axisHeight + labelSpacer)
+    .text(model.get("label"));
+  const labelHeight = label.node().getBBox().height;
 
   // final styling
   const finalHeight =

--- a/xdggs/plotting/control.css
+++ b/xdggs/plotting/control.css
@@ -1,12 +1,8 @@
 .xdggs-control-panel {
   display: grid;
   grid-template-columns: max-content max-content max-content;
-  justify-content: space-between;
-  box-sizing: box-content;
+  column-gap: 10px;
+  justify-content: center;
 
   padding: 10px;
-}
-
-.xdggs-control-panel > :nth-child(3n + 1) {
-  justify-content: start;
 }

--- a/xdggs/plotting/control.css
+++ b/xdggs/plotting/control.css
@@ -1,0 +1,5 @@
+.xdggs-control-panel {
+  display: grid;
+  grid-template-columns: max-content max-content max-content;
+  column-gap: 10px;
+}

--- a/xdggs/plotting/control.css
+++ b/xdggs/plotting/control.css
@@ -1,5 +1,12 @@
 .xdggs-control-panel {
   display: grid;
   grid-template-columns: max-content max-content max-content;
-  column-gap: 10px;
+  justify-content: space-between;
+  box-sizing: box-content;
+
+  padding: 10px;
+}
+
+.xdggs-control-panel > :nth-child(3n + 1) {
+  justify-content: start;
 }

--- a/xdggs/plotting/control.js
+++ b/xdggs/plotting/control.js
@@ -1,0 +1,21 @@
+export default {
+  initialize({ model, signal }) {},
+  async render({ model, el, signal, host }) {
+    el.classList.add("xdggs-control-panel");
+
+    const variableChooser = await host.getWidget(model.get("variable_chooser"));
+    const sliders = await host.getWidget(model.get("dimension_sliders"));
+    const colorbar = await host.getWidget(model.get("colorbar"));
+
+    let variableElement = document.createElement("div");
+    let slidersElement = document.createElement("div");
+    let colorbarElement = document.createElement("div");
+    el.appendChild(variableElement);
+    el.appendChild(slidersElement);
+    el.appendChild(colorbarElement);
+
+    await variableChooser.render({ el: variableElement, model, signal, host });
+    await sliders.render({ el: slidersElement, model, signal, host });
+    await colorbar.render({ el: colorbarElement, model, signal, host });
+  },
+};

--- a/xdggs/plotting/control.py
+++ b/xdggs/plotting/control.py
@@ -1,0 +1,19 @@
+import pathlib
+
+import anywidget
+
+root = pathlib.Path(__file__).parent
+
+
+class ControlPanel(anywidget.AnyWidget):
+    _esm = root / "control.js"
+    _css = root / "control.css"
+
+    # controls:
+    # - one dropdown (if available), otherwise disable?
+    # - a grid of sliders (use a label to align sliders and descriptions)
+    # - a colorbar
+
+    variable_chooser = anywidget.WidgetTrait().tag(sync=True)
+    dimension_sliders = anywidget.WidgetTrait().tag(sync=True)
+    colorbar = anywidget.WidgetTrait().tag(sync=True)

--- a/xdggs/plotting/dimensions.css
+++ b/xdggs/plotting/dimensions.css
@@ -2,7 +2,7 @@
   display: grid;
   padding: 5px;
   column-gap: 10px;
-  row-gap: 2px;
+  row-gap: 5px;
   grid-template-columns: max-content max-content var(
       --xdggs-dimension-value-width
     );
@@ -14,6 +14,10 @@
   justify-self: end;
 }
 
+.xdggs-dimension-sliders > :nth-child(3n + 2) {
+  margin: 0px 5px;
+}
+
 @import url("https://esm.sh/nouislider@15.8.1/dist/nouislider.css");
 
 .xdggs-slider {
@@ -22,8 +26,6 @@
   border-radius: 2px;
   background: #d9d9d9;
   box-shadow: none;
-
-  margin: 1px 5px 1px 5px;
 
   min-width: 100px;
   max-width: 100%;
@@ -49,4 +51,23 @@
 .xdggs-slider .noUi-handle::before,
 .xdggs-slider .noUi-handle::after {
   display: none;
+}
+
+.xdggs-slider[disabled] {
+  background: #d9d9d9;
+}
+
+.xdggs-slider[disabled] .noUi-connect {
+  background: #bdbdbd;
+}
+
+.xdggs-slider[disabled] .noUi-handle {
+  background: #f0f0f0;
+  border-color: #bdbdbd;
+  box-shadow: none;
+}
+
+.xdggs-slider[disabled] .noUi-handle:hover,
+.xdggs-slider[disabled] .noUi-handle:active {
+  box-shadow: none;
 }

--- a/xdggs/plotting/dimensions.css
+++ b/xdggs/plotting/dimensions.css
@@ -27,7 +27,7 @@
   background: #d9d9d9;
   box-shadow: none;
 
-  min-width: 100px;
+  min-width: 200px;
   max-width: 100%;
 }
 

--- a/xdggs/plotting/dimensions.css
+++ b/xdggs/plotting/dimensions.css
@@ -1,3 +1,5 @@
+@import url("https://esm.sh/nouislider@15.8.1/dist/nouislider.css");
+
 .xdggs-dimension-sliders {
   display: grid;
   padding: 5px;
@@ -17,8 +19,6 @@
 .xdggs-dimension-sliders > :nth-child(3n + 2) {
   margin: 0px 5px;
 }
-
-@import url("https://esm.sh/nouislider@15.8.1/dist/nouislider.css");
 
 .xdggs-slider {
   height: 4px;

--- a/xdggs/plotting/dimensions.css
+++ b/xdggs/plotting/dimensions.css
@@ -3,7 +3,7 @@
   padding: 5px;
   column-gap: 10px;
   row-gap: 2px;
-  grid-template-columns: max-content minmax(0, max-content) var(
+  grid-template-columns: max-content max-content var(
       --xdggs-dimension-value-width
     );
   align-items: center;
@@ -12,4 +12,41 @@
 
 .xdggs-dimension-sliders > :nth-child(3n) {
   justify-self: end;
+}
+
+@import url("https://esm.sh/nouislider@15.8.1/dist/nouislider.css");
+
+.xdggs-slider {
+  height: 4px;
+  border: none;
+  border-radius: 2px;
+  background: #d9d9d9;
+  box-shadow: none;
+
+  margin: 1px 5px 1px 5px;
+
+  min-width: 100px;
+  max-width: 100%;
+}
+
+.xdggs-slider .noUi-connect {
+  background: #2196f3;
+}
+
+.xdggs-slider .noUi-handle {
+  width: 16px;
+  height: 16px;
+  top: -6px;
+  right: -8px;
+
+  border: 1px solid #bdbdbd;
+  border-radius: 50%;
+  background: #fff;
+
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
+}
+
+.xdggs-slider .noUi-handle::before,
+.xdggs-slider .noUi-handle::after {
+  display: none;
 }

--- a/xdggs/plotting/dimensions.css
+++ b/xdggs/plotting/dimensions.css
@@ -1,0 +1,15 @@
+.xdggs-dimension-sliders {
+  display: grid;
+  padding: 5px;
+  column-gap: 10px;
+  row-gap: 2px;
+  grid-template-columns: max-content minmax(0, max-content) var(
+      --xdggs-dimension-value-width
+    );
+  align-items: center;
+  align-self: start;
+}
+
+.xdggs-dimension-sliders > :nth-child(3n) {
+  justify-self: end;
+}

--- a/xdggs/plotting/dimensions.js
+++ b/xdggs/plotting/dimensions.js
@@ -38,31 +38,40 @@ export default {
     let dimensions = model.get("dimensions");
     let enabled = model.get("dimension_available");
     let values = model.get("dimension_values");
+    let labels = model.get("dimension_labels") ?? {};
 
     noUiSlider.cssClasses.target += " xdggs-slider";
 
     el.classList.add("xdggs-dimension-sliders");
     const digits = Math.max(...Object.values(dimensions)).toString().length;
-    el.style.setProperty("--xdggs-dimension-value-width", `${digits}ch`);
+    const labelChars = Math.max(
+      ...Object.values(labels).map((labelList) =>
+        Math.max(...labelList.map((label) => label.length)),
+      ),
+    );
+
+    el.style.setProperty(
+      "--xdggs-dimension-value-width",
+      `${Math.max(digits, labelChars)}ch`,
+    );
 
     const sliders = Object.fromEntries(
       Object.keys(dimensions).map((name) => {
-        const label = document.createElement("span");
+        const nameLabel = document.createElement("span");
         const slider = document.createElement("div");
         const valueLabel = document.createElement("span");
 
-        el.appendChild(label);
+        el.appendChild(nameLabel);
         el.appendChild(slider);
         el.appendChild(valueLabel);
 
-        label.innerText = name;
+        nameLabel.innerText = name;
 
         const value = values[name];
-
         slider.id = `xdggs-slider-${name}`;
 
         const max = dimensions[name] - 1;
-        console.log("range:", 0, max);
+
         noUiSlider.create(slider, {
           start: values[name],
           step: 1,
@@ -75,7 +84,14 @@ export default {
 
         slider.noUiSlider.on("update.xdggs", ([formatted_value]) => {
           const value = parseInt(formatted_value);
-          valueLabel.innerText = value;
+          let label;
+          if (labels[name]) {
+            label = labels[name][value];
+          } else {
+            label = value;
+          }
+
+          valueLabel.innerText = label;
 
           const new_values = { ...model.get("dimension_values") };
           new_values[name] = value;

--- a/xdggs/plotting/dimensions.js
+++ b/xdggs/plotting/dimensions.js
@@ -8,6 +8,14 @@ function setDisabled(slider, value) {
   }
 }
 
+function formatLabel(labels, index) {
+  if (labels !== undefined && labels.length != 0) {
+    return labels[index];
+  } else {
+    return index;
+  }
+}
+
 export default {
   initialize({ model, signal }) {
     const dimensions = model.get("dimensions");
@@ -89,14 +97,7 @@ export default {
         sliderWidget.noUiSlider.on("update.xdggs", ([formatted_value]) => {
           const value = parseInt(formatted_value);
 
-          let label;
-          if (labels[name] !== undefined) {
-            label = labels[name][value];
-          } else {
-            label = value;
-          }
-
-          valueLabel.innerText = label;
+          valueLabel.innerText = formatLabel(labels[name], value);
 
           const new_values = { ...model.get("dimension_values") };
           new_values[name] = value;
@@ -105,7 +106,7 @@ export default {
         });
 
         /* value label */
-        valueLabel.innerText = value;
+        valueLabel.innerText = formatLabel(labels[name], value);
 
         return [name, sliderWidget];
       }),

--- a/xdggs/plotting/dimensions.js
+++ b/xdggs/plotting/dimensions.js
@@ -23,7 +23,7 @@ export default {
     }
 
     let values = model.get("dimension_values");
-    if (!values || Object.entries(enabled).length == 0) {
+    if (!values || Object.entries(values).length == 0) {
       const values = Object.fromEntries(
         Object.keys(dimensions).map((name) => {
           return [name, 0];

--- a/xdggs/plotting/dimensions.js
+++ b/xdggs/plotting/dimensions.js
@@ -1,3 +1,13 @@
+import * as noUiSlider from "https://esm.sh/nouislider@15.8.1";
+
+function setDisabled(slider, value) {
+  if (value) {
+    slider.noUiSlider.disable();
+  } else {
+    slider.noUiSlider.enable();
+  }
+}
+
 export default {
   initialize({ model, signal }) {
     const dimensions = model.get("dimensions");
@@ -29,6 +39,8 @@ export default {
     let enabled = model.get("dimension_available");
     let values = model.get("dimension_values");
 
+    noUiSlider.cssClasses.target += " xdggs-slider";
+
     el.classList.add("xdggs-dimension-sliders");
     const digits = Math.max(...Object.values(dimensions)).toString().length;
     el.style.setProperty("--xdggs-dimension-value-width", `${digits}ch`);
@@ -36,35 +48,46 @@ export default {
     const sliders = Object.fromEntries(
       Object.keys(dimensions).map((name) => {
         const label = document.createElement("span");
+        const slider = document.createElement("div");
+        const valueLabel = document.createElement("span");
+
+        el.appendChild(label);
+        el.appendChild(slider);
+        el.appendChild(valueLabel);
+
         label.innerText = name;
 
         const value = values[name];
 
-        let input = document.createElement("input");
-        input.setAttribute("type", "range");
-        input.setAttribute("min", 0);
-        input.setAttribute("value", values[name]);
-        input.setAttribute("max", dimensions[name]);
+        slider.id = `xdggs-slider-${name}`;
 
-        input.disabled = !enabled[name];
+        const max = dimensions[name] - 1;
+        console.log("range:", 0, max);
+        noUiSlider.create(slider, {
+          start: values[name],
+          step: 1,
+          range: { min: 0, max: dimensions[name] - 1 },
+          connect: "lower",
+        });
+        setDisabled(slider, !enabled[name]);
 
-        let valueLabel = document.createElement("span");
         valueLabel.innerText = value;
 
-        input.oninput = () => {
-          valueLabel.innerText = input.value;
+        slider.noUiSlider.on("update.xdggs", ([formatted_value]) => {
+          const value = parseInt(formatted_value);
+          valueLabel.innerText = value;
 
           const new_values = { ...model.get("dimension_values") };
-          new_values[name] = Number(input.value);
+          new_values[name] = value;
           model.set("dimension_values", new_values);
           model.save_changes();
-        };
+        });
 
         el.appendChild(label);
-        el.appendChild(input);
+        el.appendChild(slider);
         el.appendChild(valueLabel);
 
-        return [name, input];
+        return [name, slider];
       }),
     );
 
@@ -72,7 +95,7 @@ export default {
       let enabled = model.get("dimension_available");
 
       Object.entries(enabled).forEach(([name, value]) => {
-        sliders[name].disabled = !value;
+        setDisabled(sliders[name], !enabled[name]);
       });
     });
   },

--- a/xdggs/plotting/dimensions.js
+++ b/xdggs/plotting/dimensions.js
@@ -65,27 +65,32 @@ export default {
         el.appendChild(slider);
         el.appendChild(valueLabel);
 
+        /* name label */
         nameLabel.innerText = name;
 
+        /* slider */
         const value = values[name];
         slider.id = `xdggs-slider-${name}`;
+        slider.classList.add("xdggs-slider-container");
+
+        const sliderWidget = document.createElement("div");
+        slider.appendChild(sliderWidget);
 
         const max = dimensions[name] - 1;
 
-        noUiSlider.create(slider, {
+        noUiSlider.create(sliderWidget, {
           start: values[name],
           step: 1,
           range: { min: 0, max: dimensions[name] - 1 },
           connect: "lower",
         });
-        setDisabled(slider, !enabled[name]);
+        setDisabled(sliderWidget, !enabled[name]);
 
-        valueLabel.innerText = value;
-
-        slider.noUiSlider.on("update.xdggs", ([formatted_value]) => {
+        sliderWidget.noUiSlider.on("update.xdggs", ([formatted_value]) => {
           const value = parseInt(formatted_value);
+
           let label;
-          if (labels[name]) {
+          if (labels[name] !== undefined) {
             label = labels[name][value];
           } else {
             label = value;
@@ -99,7 +104,10 @@ export default {
           model.save_changes();
         });
 
-        return [name, slider];
+        /* value label */
+        valueLabel.innerText = value;
+
+        return [name, sliderWidget];
       }),
     );
 

--- a/xdggs/plotting/dimensions.js
+++ b/xdggs/plotting/dimensions.js
@@ -1,32 +1,79 @@
 export default {
-  initialize({ model, signal }) {},
+  initialize({ model, signal }) {
+    const dimensions = model.get("dimensions");
+
+    let enabled = model.get("dimension_available");
+    if (!enabled) {
+      const enabled = Object.fromEntries(
+        Object.keys(dimensions).map((name) => {
+          return [name, true];
+        }),
+      );
+      model.set("dimension_available", enabled);
+    }
+
+    let values = model.get("dimension_values");
+    if (!values) {
+      const values = Object.fromEntries(
+        Object.keys(dimensions).map((name) => {
+          return [name, 0];
+        }),
+      );
+      model.set("dimension_values", values);
+    }
+
+    model.save_changes();
+  },
   async render({ model, el, signal, host }) {
-    const values = model.get("dimensions");
+    let dimensions = model.get("dimensions");
+    let enabled = model.get("dimension_available");
+    let values = model.get("dimension_values");
 
     el.style.setProperty("display", "grid");
     el.style.setProperty("padding", "5px");
     el.style.setProperty("column-gap", "10px");
 
-    Object.entries(values).forEach(([name, value]) => {
-      const label = document.createElement("span");
-      label.innerText = name;
+    const sliders = Object.fromEntries(
+      Object.keys(dimensions).map((name) => {
+        const label = document.createElement("span");
+        label.innerText = name;
 
-      let input = document.createElement("input");
-      input.setAttribute("type", "range");
-      input.setAttribute("min", 0);
-      input.setAttribute("value", 0);
-      input.setAttribute("max", value);
+        const value = values[name];
 
-      let valueLabel = document.createElement("span");
-      valueLabel.innerText = value;
+        let input = document.createElement("input");
+        input.setAttribute("type", "range");
+        input.setAttribute("min", 0);
+        input.setAttribute("value", values[name]);
+        input.setAttribute("max", dimensions[name]);
 
-      input.oninput = () => {
-        valueLabel.innerText = input.value;
-      };
+        input.disabled = !enabled[name];
 
-      el.appendChild(label);
-      el.appendChild(input);
-      el.appendChild(valueLabel);
+        let valueLabel = document.createElement("span");
+        valueLabel.innerText = value;
+
+        input.oninput = () => {
+          valueLabel.innerText = input.value;
+
+          const new_values = { ...model.get("dimension_values") };
+          new_values[name] = Number(input.value);
+          model.set("dimension_values", new_values);
+          model.save_changes();
+        };
+
+        el.appendChild(label);
+        el.appendChild(input);
+        el.appendChild(valueLabel);
+
+        return [name, input];
+      }),
+    );
+
+    model.on("change:dimension_available", () => {
+      let enabled = model.get("dimension_available");
+
+      Object.entries(enabled).forEach(([name, value]) => {
+        sliders[name].disabled = !value;
+      });
     });
 
     el.style.setProperty(

--- a/xdggs/plotting/dimensions.js
+++ b/xdggs/plotting/dimensions.js
@@ -3,7 +3,7 @@ export default {
     const dimensions = model.get("dimensions");
 
     let enabled = model.get("dimension_available");
-    if (!enabled) {
+    if (!enabled || Object.entries(enabled).length == 0) {
       const enabled = Object.fromEntries(
         Object.keys(dimensions).map((name) => {
           return [name, true];
@@ -13,7 +13,7 @@ export default {
     }
 
     let values = model.get("dimension_values");
-    if (!values) {
+    if (!values || Object.entries(enabled).length == 0) {
       const values = Object.fromEntries(
         Object.keys(dimensions).map((name) => {
           return [name, 0];
@@ -29,9 +29,9 @@ export default {
     let enabled = model.get("dimension_available");
     let values = model.get("dimension_values");
 
-    el.style.setProperty("display", "grid");
-    el.style.setProperty("padding", "5px");
-    el.style.setProperty("column-gap", "10px");
+    el.classList.add("xdggs-dimension-sliders");
+    const digits = Math.max(...Object.values(dimensions)).toString().length;
+    el.style.setProperty("--xdggs-dimension-value-width", `${digits}ch`);
 
     const sliders = Object.fromEntries(
       Object.keys(dimensions).map((name) => {
@@ -75,10 +75,5 @@ export default {
         sliders[name].disabled = !value;
       });
     });
-
-    el.style.setProperty(
-      "grid-template-columns",
-      "max-content max-content max-content",
-    );
   },
 };

--- a/xdggs/plotting/dimensions.js
+++ b/xdggs/plotting/dimensions.js
@@ -83,10 +83,6 @@ export default {
           model.save_changes();
         });
 
-        el.appendChild(label);
-        el.appendChild(slider);
-        el.appendChild(valueLabel);
-
         return [name, slider];
       }),
     );

--- a/xdggs/plotting/dimensions.js
+++ b/xdggs/plotting/dimensions.js
@@ -1,5 +1,7 @@
 import * as noUiSlider from "https://esm.sh/nouislider@15.8.1";
 
+noUiSlider.cssClasses.target += " xdggs-slider";
+
 function setDisabled(slider, value) {
   if (value) {
     slider.noUiSlider.disable();
@@ -47,8 +49,6 @@ export default {
     let enabled = model.get("dimension_available");
     let values = model.get("dimension_values");
     let labels = model.get("dimension_labels") ?? {};
-
-    noUiSlider.cssClasses.target += " xdggs-slider";
 
     el.classList.add("xdggs-dimension-sliders");
     const digits = Math.max(...Object.values(dimensions)).toString().length;

--- a/xdggs/plotting/dimensions.js
+++ b/xdggs/plotting/dimensions.js
@@ -1,0 +1,37 @@
+export default {
+  initialize({ model, signal }) {},
+  async render({ model, el, signal, host }) {
+    const values = model.get("dimensions");
+
+    el.style.setProperty("display", "grid");
+    el.style.setProperty("padding", "5px");
+    el.style.setProperty("column-gap", "10px");
+
+    Object.entries(values).forEach(([name, value]) => {
+      const label = document.createElement("span");
+      label.innerText = name;
+
+      let input = document.createElement("input");
+      input.setAttribute("type", "range");
+      input.setAttribute("min", 0);
+      input.setAttribute("value", 0);
+      input.setAttribute("max", value);
+
+      let valueLabel = document.createElement("span");
+      valueLabel.innerText = value;
+
+      input.oninput = () => {
+        valueLabel.innerText = input.value;
+      };
+
+      el.appendChild(label);
+      el.appendChild(input);
+      el.appendChild(valueLabel);
+    });
+
+    el.style.setProperty(
+      "grid-template-columns",
+      "max-content max-content max-content",
+    );
+  },
+};

--- a/xdggs/plotting/dimensions.py
+++ b/xdggs/plotting/dimensions.py
@@ -8,6 +8,7 @@ root = pathlib.Path(__file__).parent
 
 class DimensionSliders(anywidget.AnyWidget):
     _esm = root / "dimensions.js"
+    _css = root / "dimensions.css"
 
     dimensions = traitlets.Dict(value_trait=traitlets.Int()).tag(sync=True)
 

--- a/xdggs/plotting/dimensions.py
+++ b/xdggs/plotting/dimensions.py
@@ -13,4 +13,7 @@ class DimensionSliders(anywidget.AnyWidget):
     dimensions = traitlets.Dict(value_trait=traitlets.Int()).tag(sync=True)
 
     dimension_values = traitlets.Dict(value_trait=traitlets.Int()).tag(sync=True)
+    dimension_labels = traitlets.Dict(
+        value_trait=traitlets.List(trait=traitlets.Unicode())
+    ).tag(sync=True)
     dimension_available = traitlets.Dict(value_trait=traitlets.Bool()).tag(sync=True)

--- a/xdggs/plotting/dimensions.py
+++ b/xdggs/plotting/dimensions.py
@@ -1,0 +1,12 @@
+import pathlib
+
+import anywidget
+import traitlets
+
+root = pathlib.Path(__file__).parent
+
+
+class DimensionSliders(anywidget.AnyWidget):
+    _esm = root / "dimensions.js"
+
+    dimensions = traitlets.Dict(values_trait=traitlets.Int()).tag(sync=True)

--- a/xdggs/plotting/dimensions.py
+++ b/xdggs/plotting/dimensions.py
@@ -9,4 +9,7 @@ root = pathlib.Path(__file__).parent
 class DimensionSliders(anywidget.AnyWidget):
     _esm = root / "dimensions.js"
 
-    dimensions = traitlets.Dict(values_trait=traitlets.Int()).tag(sync=True)
+    dimensions = traitlets.Dict(value_trait=traitlets.Int()).tag(sync=True)
+
+    dimension_values = traitlets.Dict(value_trait=traitlets.Int()).tag(sync=True)
+    dimension_available = traitlets.Dict(value_trait=traitlets.Bool()).tag(sync=True)

--- a/xdggs/plotting/map.css
+++ b/xdggs/plotting/map.css
@@ -1,0 +1,4 @@
+.xdggs-map {
+  display: grid;
+  grid-template-rows: 80% 20%;
+}

--- a/xdggs/plotting/map.css
+++ b/xdggs/plotting/map.css
@@ -3,4 +3,5 @@
   grid-template-rows: 4fr 1fr;
   grid-template-columns: 1fr;
   height: fit-content;
+  width: fit-content;
 }

--- a/xdggs/plotting/map.css
+++ b/xdggs/plotting/map.css
@@ -1,5 +1,6 @@
 .xdggs-map {
   display: grid;
   grid-template-rows: 4fr 1fr;
+  grid-template-columns: 1fr;
   height: fit-content;
 }

--- a/xdggs/plotting/map.css
+++ b/xdggs/plotting/map.css
@@ -1,4 +1,5 @@
 .xdggs-map {
   display: grid;
-  grid-template-rows: 80% 20%;
+  grid-template-rows: 4fr 1fr;
+  height: fit-content;
 }

--- a/xdggs/plotting/map.js
+++ b/xdggs/plotting/map.js
@@ -1,132 +1,17 @@
-async function unpack_models(model_ids, manager) {
-  return Promise.all(
-    model_ids.map((id) => manager.get_model(id.slice("IPY_MODEL_".length))),
-  );
-}
+export default {
+  async render({ model, el, signal, host }) {
+    el.classList.add("xdggs-map");
 
-async function create_child_views(models, manager) {
-  return Promise.all(models.map((m) => manager.create_view(m)));
-}
+    const map = await host.getWidget(model.get("map"));
+    const control = await host.getWidget(model.get("control"));
 
-function construct_slider_row(name, slider_view) {
-  let row = document.createElement("div");
-  row.style.setProperty("display", "grid");
-  row.style.setProperty("padding", "3px");
-  row.style.setProperty("grid-template-columns", "1fr 5fr 1fr");
-  row.style.setProperty("height", "fit-content");
+    let mapElement = document.createElement("div");
+    let controlElement = document.createElement("div");
 
-  // play button for animation
-  /* let button = document.createElement("button");
-   * button.innerHTML = "▶";
-   * button.style.setProperty("width", "40px");
-   * row.appendChild(button);
-   */
+    el.appendChild(mapElement);
+    el.appendChild(controlElement);
 
-  // dimension name
-  let name_el = document.createElement("div");
-  name_el.innerHTML = name;
-  name_el.style.setProperty("align-content", "center");
-  name_el.style.setProperty("padding-left", "2px");
-  row.appendChild(name_el);
-
-  // slider widget
-  row.appendChild(slider_view.el);
-
-  // value label
-  let readout = document.createElement("div");
-  readout.style.setProperty("padding-left", "2px");
-  readout.style.setProperty("align-content", "center");
-  readout.id = `${name}_label`;
-  readout.innerHTML = "value";
-  row.appendChild(readout);
-
-  return row;
-}
-
-async function create_controls(model) {
-  const controls = document.createElement("div");
-  controls.style.setProperty("padding", "5px");
-  controls.style.setProperty("display", "grid");
-  controls.style.setProperty("grid-template-columns", "2fr 3fr 3fr");
-
-  // variable drop down
-  const variables = model.get("variables");
-  let variable_model = await unpack_models([variables], model.widget_manager);
-  let variable_views = await create_child_views(
-    variable_model,
-    model.widget_manager,
-  );
-  let variable_view = variable_views[0];
-  controls.appendChild(variable_view.el);
-
-  // sliders
-  let dimension_sliders = document.createElement("div");
-  dimension_sliders.style.setProperty("display", "grid");
-  dimension_sliders.style.setProperty("grid-template-columns", "1fr");
-
-  const slider_ids = model.get("sliders");
-  const slider_models = await unpack_models(
-    Object.values(slider_ids),
-    model.widget_manager,
-  );
-  const slider_views = await create_child_views(
-    slider_models,
-    model.widget_manager,
-  );
-
-  const dimension_indices = model.get("dimensions");
-  const coordinate_values = model.get("coordinates");
-
-  let zipped = Object.keys(dimension_indices).map((name, index) => [
-    name,
-    slider_views[index],
-    slider_models[index],
-    dimension_indices[name],
-    coordinate_values[name],
-  ]);
-  zipped.forEach(
-    ([name, slider_view, slider_model, dimension_index, values]) => {
-      let row = construct_slider_row(name, slider_view);
-
-      let label = row.children[2];
-      label.innerHTML = values[0];
-
-      // link slider change with label (index => values[index] => label.value)
-      slider_model.on("change:value", (model, new_value, context) => {
-        label.innerHTML = values[new_value];
-      });
-
-      dimension_sliders.appendChild(row);
-    },
-  );
-
-  controls.appendChild(dimension_sliders);
-
-  // colorbar
-  const colorbar = model.get("colorbar");
-  let colorbar_models = await unpack_models([colorbar], model.widget_manager);
-  let colorbar_views = await create_child_views(
-    colorbar_models,
-    model.widget_manager,
-  );
-  let colorbar_view = colorbar_views[0];
-  controls.appendChild(colorbar_view.el);
-
-  return controls;
-}
-
-async function render({ model, el }) {
-  // map
-  let map_id = model.get("map");
-  let map_models = await unpack_models([map_id], model.widget_manager);
-  let map_views = await create_child_views(map_models, model.widget_manager);
-  let map_view = map_views[0];
-  map_view.el.style.setProperty("height", "80%");
-  el.appendChild(map_view.el);
-
-  // controls
-  const controls = await create_controls(model);
-  el.appendChild(controls);
-}
-
-export default { render };
+    await map.render({ model, el: mapElement, signal, host });
+    await control.render({ model, el: controlElement, signal, host });
+  },
+};

--- a/xdggs/plotting/map.py
+++ b/xdggs/plotting/map.py
@@ -1,7 +1,6 @@
 import pathlib
 
 import anywidget
-import ipywidgets as ipw
 import traitlets
 
 
@@ -13,12 +12,10 @@ class MapWithControls(anywidget.AnyWidget):
     _esm = pathlib.Path(__file__).parent / "map.js"
 
     # the base map
-    map = traitlets.Instance(ipw.DOMWidget).tag(sync=True, **ipw.widget_serialization)
+    map = anywidget.WidgetTrait().tag(sync=True)
 
     # for choosing variables
-    variables = traitlets.Instance(ipw.DOMWidget).tag(
-        sync=True, **ipw.widget_serialization
-    )
+    variables = anywidget.WidgetTrait().tag(sync=True)
 
     # for choosing values along dimensions
     dimensions = traitlets.Dict(value_trait=traitlets.Int()).tag(sync=True)
@@ -26,14 +23,10 @@ class MapWithControls(anywidget.AnyWidget):
         value_trait=traitlets.List(trait=traitlets.Unicode())
     ).tag(sync=True)
 
-    sliders = traitlets.Dict(value_trait=traitlets.Instance(ipw.DOMWidget)).tag(
-        sync=True, **ipw.widget_serialization
-    )
+    sliders = traitlets.Dict(value_trait=anywidget.WidgetTrait()).tag(sync=True)
 
     # the colorbar
-    colorbar = traitlets.Instance(ipw.DOMWidget).tag(
-        sync=True, **ipw.widget_serialization
-    )
+    colorbar = anywidget.WidgetTrait().tag(sync=True)
 
     @property
     def layers(self):

--- a/xdggs/plotting/map.py
+++ b/xdggs/plotting/map.py
@@ -1,32 +1,19 @@
 import pathlib
 
 import anywidget
-import traitlets
+
+root = pathlib.Path(__file__).parent
 
 
 class MapWithControls(anywidget.AnyWidget):
-    # controls:
-    # - one dropdown (if available), otherwise disable?
-    # - a grid of sliders (use a label to align sliders and descriptions)
-    # - maybe a colorbar
-    _esm = pathlib.Path(__file__).parent / "map.js"
+    _esm = root / "map.js"
+    _css = root / "map.css"
 
-    # the base map
+    # base map
     map = anywidget.WidgetTrait().tag(sync=True)
 
-    # for choosing variables
-    variables = anywidget.WidgetTrait().tag(sync=True)
-
-    # for choosing values along dimensions
-    dimensions = traitlets.Dict(value_trait=traitlets.Int()).tag(sync=True)
-    coordinates = traitlets.Dict(
-        value_trait=traitlets.List(trait=traitlets.Unicode())
-    ).tag(sync=True)
-
-    sliders = traitlets.Dict(value_trait=anywidget.WidgetTrait()).tag(sync=True)
-
-    # the colorbar
-    colorbar = anywidget.WidgetTrait().tag(sync=True)
+    # control panel
+    control = anywidget.WidgetTrait().tag(sync=True)
 
     @property
     def layers(self):

--- a/xdggs/plotting/variable_chooser.css
+++ b/xdggs/plotting/variable_chooser.css
@@ -1,0 +1,3 @@
+.xdggs-variable-select {
+  min-width: 15ch;
+}

--- a/xdggs/plotting/variable_chooser.js
+++ b/xdggs/plotting/variable_chooser.js
@@ -1,0 +1,66 @@
+function replaceOptions({ el, variables, value }) {
+  if (!variables || variables.length == 0) {
+    el.disabled = true;
+    return;
+  }
+
+  const options = variables.map((name) => {
+    const option = document.createElement("option");
+    option.value = name;
+    option.innerText = name;
+
+    return option;
+  });
+  el.replaceChildren(...options);
+
+  el.value = value;
+  el.disabled = false;
+}
+
+export default {
+  initialize({ model, signal }) {
+    const variables = model.get("variables");
+
+    if (!variables) {
+      model.set("value", variables[0]);
+      model.save_changes();
+    }
+  },
+  render({ model, el, signal, host }) {
+    let variables = model.get("variables");
+
+    const drop_down = document.createElement("select");
+    drop_down.name = "variable";
+
+    let value = model.get("value");
+    if (!value || !(value in variables)) {
+      value = variables[0];
+      model.set("value", value);
+      model.save_changes();
+    }
+
+    replaceOptions({ el: drop_down, variables, value });
+
+    drop_down.onchange = () => {
+      model.set("value", drop_down.value);
+      model.save_changes();
+    };
+
+    model.on("change:value", () => {
+      drop_down.value = model.get("value");
+    });
+    model.on("change:variables", () => {
+      const variables = model.get("variables");
+      let value = model.get("value");
+      if (!value || !(value in variables)) {
+        value = variables[0];
+        model.set("value", value);
+        model.save_changes();
+      }
+
+      replaceOptions({ el: drop_down, variables, value });
+    });
+
+    el.appendChild(drop_down);
+  },
+};

--- a/xdggs/plotting/variable_chooser.js
+++ b/xdggs/plotting/variable_chooser.js
@@ -1,5 +1,5 @@
 function replaceOptions({ el, variables, value }) {
-  if (!variables || variables.length == 0) {
+  if (!variables || variables.length <= 1) {
     el.disabled = true;
     return;
   }

--- a/xdggs/plotting/variable_chooser.js
+++ b/xdggs/plotting/variable_chooser.js
@@ -30,6 +30,7 @@ export default {
     let variables = model.get("variables");
 
     const drop_down = document.createElement("select");
+    drop_down.classList.add("xdggs-variable-select");
     drop_down.name = "variable";
 
     let value = model.get("value");

--- a/xdggs/plotting/variable_chooser.js
+++ b/xdggs/plotting/variable_chooser.js
@@ -53,8 +53,13 @@ export default {
     model.on("change:variables", () => {
       const variables = model.get("variables");
       let value = model.get("value");
-      if (!value || !(value in variables)) {
+      if (!variables || variables.length == 0) {
+        value = "";
+      } else if (!value || !(value in variables)) {
         value = variables[0];
+      }
+
+      if (value !== model.get("value")) {
         model.set("value", value);
         model.save_changes();
       }

--- a/xdggs/plotting/variable_chooser.py
+++ b/xdggs/plotting/variable_chooser.py
@@ -18,6 +18,8 @@ class VariableChooser(anywidget.AnyWidget):
     def _valid_data(self, proposal: str) -> bool:
         if not self.variables:
             return ""
+        elif proposal["value"] is None:
+            return ""
         elif proposal["value"] not in self.variables:
             raise traitlets.TraitError(
                 f"The selected value must be chosen from the list of variables: [{', '.join(self.variables)}]"

--- a/xdggs/plotting/variable_chooser.py
+++ b/xdggs/plotting/variable_chooser.py
@@ -16,7 +16,9 @@ class VariableChooser(anywidget.AnyWidget):
 
     @validate("value")
     def _valid_data(self, proposal: str) -> bool:
-        if proposal["value"] not in self.variables:
+        if not self.variables:
+            return None
+        elif proposal["value"] not in self.variables:
             raise traitlets.TraitError(
                 f"The selected value must be chosen from the list of variables: [{', '.join(self.variables)}]"
             )

--- a/xdggs/plotting/variable_chooser.py
+++ b/xdggs/plotting/variable_chooser.py
@@ -1,0 +1,22 @@
+import pathlib
+
+import anywidget
+import traitlets
+from traitlets import validate
+
+root = pathlib.Path(__file__).parent
+
+
+class VariableChooser(anywidget.AnyWidget):
+    _esm = root / "variable_chooser.js"
+
+    variables = traitlets.List(value_trait=traitlets.Unicode()).tag(sync=True)
+    value = traitlets.Unicode().tag(sync=True)
+
+    @validate("value")
+    def _valid_data(self, proposal: str) -> bool:
+        if proposal["value"] not in self.variables:
+            raise traitlets.TraitError(
+                f"The selected value must be chosen from the list of variables: [{', '.join(self.variables)}]"
+            )
+        return proposal["value"]

--- a/xdggs/plotting/variable_chooser.py
+++ b/xdggs/plotting/variable_chooser.py
@@ -17,7 +17,7 @@ class VariableChooser(anywidget.AnyWidget):
     @validate("value")
     def _valid_data(self, proposal: str) -> bool:
         if not self.variables:
-            return None
+            return ""
         elif proposal["value"] not in self.variables:
             raise traitlets.TraitError(
                 f"The selected value must be chosen from the list of variables: [{', '.join(self.variables)}]"

--- a/xdggs/plotting/variable_chooser.py
+++ b/xdggs/plotting/variable_chooser.py
@@ -9,6 +9,7 @@ root = pathlib.Path(__file__).parent
 
 class VariableChooser(anywidget.AnyWidget):
     _esm = root / "variable_chooser.js"
+    _css = root / "variable_chooser.css"
 
     variables = traitlets.List(value_trait=traitlets.Unicode()).tag(sync=True)
     value = traitlets.Unicode().tag(sync=True)

--- a/xdggs/plotting/variable_chooser.py
+++ b/xdggs/plotting/variable_chooser.py
@@ -11,7 +11,7 @@ class VariableChooser(anywidget.AnyWidget):
     _esm = root / "variable_chooser.js"
     _css = root / "variable_chooser.css"
 
-    variables = traitlets.List(value_trait=traitlets.Unicode()).tag(sync=True)
+    variables = traitlets.List(trait=traitlets.Unicode()).tag(sync=True)
     value = traitlets.Unicode().tag(sync=True)
 
     @validate("value")

--- a/xdggs/plotting/variables.py
+++ b/xdggs/plotting/variables.py
@@ -15,4 +15,7 @@ def construct_variable_chooser(obj):
         ]
         value = options[0] if options else None
 
+    if value is None:
+        value = ""
+
     return VariableChooser(variables=options, value=value)

--- a/xdggs/plotting/variables.py
+++ b/xdggs/plotting/variables.py
@@ -1,9 +1,9 @@
 import xarray as xr
 
+from xdggs.plotting.variable_chooser import VariableChooser
+
 
 def construct_variable_chooser(obj):
-    from ipywidgets import Dropdown
-
     if isinstance(obj, xr.DataArray):
         options = [obj.name] if obj.name is not None else []
         value = obj.name
@@ -15,9 +15,4 @@ def construct_variable_chooser(obj):
         ]
         value = options[0] if options else None
 
-    return Dropdown(
-        options=options,
-        value=value,
-        description="Variable:",
-        disabled=len(options) <= 1,
-    )
+    return VariableChooser(variables=options, value=value)


### PR DESCRIPTION
- [x] User visible changes (including notable bug fixes) are documented in `changelog.md`

This should not be visible by users (or if so would hopefully fix rendering bugs).

The failing tests / docs should be unrelated.