### PR TITLE
CI setup, dependencies and failing tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
           keyword: "[skip-ci]"
 
   cache-pixi-lock:
+    name: cache pixi lock file
     runs-on: ubuntu-slim
     needs: detect-ci-trigger
     if: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,54 @@ jobs:
         run: |
           pixi run -e $ENV tests
 
+  doctests:
+    name: Doctests | ${{ matrix.env }}
+    runs-on: ubuntu-latest
+    needs: cache-pixi-lock
+    if: needs.detect-ci-trigger.outputs.triggered == 'false'
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        env: ["ci-py313"]
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0 # Fetch all history for all branches and tags
+          persist-credentials: false
+
+      - uses: Parcels-code/pixi-lock/restore@38495788b79a5ff26009aecc15daa9a8310b8832 # v0.1.0
+        with:
+          cache-key: ${{ needs.cache-pixi-lock.outputs.cache-key }}
+
+      - name: setup environment
+        uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
+        with:
+          environments: "${{ matrix.env }}"
+          pixi-version: ${{ needs.cache-pixi-lock.outputs.pixi-version }}
+          cache: true
+          frozen: true
+
+      - name: investigate env variables
+        env:
+          ENV: ${{ matrix.env }}
+          RUNNER_OS: ${{ matrix.os }}
+        run: |
+          echo PYTHON_VERSION=$(pixi run -e $ENV python -c 'import sys; print(".".join(map(str, sys.version_info[:2])))') >> $GITHUB_ENV
+          echo RUNNER_OS=$RUNNER_OS >> $GITHUB_ENV
+
+      - name: run doctests
+        env:
+          ENV: ${{ matrix.env }}
+        run: |
+          pixi run -e $ENV doctests
+
   zizmor:
     name: GHA Security Analysis using Zizmor
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,12 +51,6 @@ jobs:
 
       - uses: Parcels-code/pixi-lock/create-and-cache@1fab4c17af8243f6ca1321bc941cf2325f46c05d # v0.1.1
         id: pixi-lock
-        with:
-          hash-files: |
-            pixi.toml
-            Cargo.toml
-            python/healpix-geo/pyproject.toml
-            python/healpix-geo/pixi.toml
 
   tests:
     name: ${{ matrix.os }} ${{ matrix.env }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -84,6 +84,7 @@ jobs:
       - uses: Parcels-code/pixi-lock/restore@38495788b79a5ff26009aecc15daa9a8310b8832 # v0.1.0
         with:
           cache-key: ${{ needs.cache-pixi-lock.outputs.cache-key }}
+          manifest-path: ${{ env.MANIFEST_PATH }}
 
       - name: setup environment
         uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -81,11 +81,18 @@ jobs:
           fetch-depth: 0 # Fetch all history for all branches and tags
           persist-credentials: false
 
+      - uses: Parcels-code/pixi-lock/restore@38495788b79a5ff26009aecc15daa9a8310b8832 # v0.1.0
+        with:
+          cache-key: ${{ needs.cache-pixi-lock.outputs.cache-key }}
+
       - name: setup environment
         uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
         with:
           manifest-path: ${{ env.MANIFEST_PATH }}
           environments: "nightly"
+          pixi-version: ${{ needs.cache-pixi-lock.outputs.pixi-version }}
+          cache: true
+          frozen: true
 
       - name: Import xdggs
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -50,6 +50,9 @@ jobs:
       run:
         shell: bash -l {0}
 
+    env:
+      MANIFEST_PATH: "ci/nightly/pixi.toml"
+
     steps:
       - name: Clone repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -57,24 +60,21 @@ jobs:
           fetch-depth: 0 # Fetch all history for all branches and tags
           persist-credentials: false
 
-      - name: remove lockfile
-        run: |
-          rm pixi.lock
-
       - name: setup environment
         uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
         with:
+          manifest-path: ${{ env.MANIFEST_PATH }}
           environments: "nightly"
 
       - name: Import xdggs
         run: |
-          pixi run -e nightly python -c "import xdggs"
+          pixi run --manifest-path "$MANIFEST_PATH" -e nightly python -c "import xdggs"
 
       - name: run tests
         if: success()
         id: status
         run: |
-          pixi run -e nightly tests -rf --report-log=pytest-log.jsonl
+          pixi run --manifest-path "$MANIFEST_PATH" -e nightly tests -rf --report-log=pytest-log.jsonl
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure() && steps.status.outcome == 'failure'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -34,17 +34,38 @@ jobs:
         with:
           keyword: "[test-upstream]"
 
-  tests:
-    name: upstream-dev
-    runs-on: ubuntu-latest
+  cache-pixi-lock:
+    runs-on: ubuntu-slim
     needs: detect-ci-trigger
     if: |
       always()
+      && github.repository_owner == 'xarray-contrib'
       && (
         (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
         || needs.detect-ci-trigger.outputs.triggered == 'true'
         || contains( github.event.pull_request.labels.*.name, 'run-upstream')
       )
+    outputs:
+      cache-key: ${{ steps.pixi-lock.outputs.cache-key }}
+      pixi-version: ${{ steps.pixi-lock.outputs.pixi-version }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: Parcels-code/pixi-lock/create-and-cache@1fab4c17af8243f6ca1321bc941cf2325f46c05d # v0.1.1
+        id: pixi-lock
+        with:
+          manifest-path: "ci/nightly/pixi.toml"
+          hash-files: |
+            pyproject.toml
+            pixi.toml
+            ci/nightly/pixi.toml
+
+  tests:
+    name: upstream-dev
+    runs-on: ubuntu-latest
+    needs: cache-pixi-lock
 
     defaults:
       run:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -35,6 +35,7 @@ jobs:
           keyword: "[test-upstream]"
 
   cache-pixi-lock:
+    name: cache pixi lock file
     runs-on: ubuntu-slim
     needs: detect-ci-trigger
     if: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -45,6 +45,10 @@ jobs:
         || needs.detect-ci-trigger.outputs.triggered == 'true'
         || contains( github.event.pull_request.labels.*.name, 'run-upstream')
       )
+
+    env:
+      MANIFEST_PATH: "ci/nightly/pixi.toml"
+
     outputs:
       cache-key: ${{ steps.pixi-lock.outputs.cache-key }}
       pixi-version: ${{ steps.pixi-lock.outputs.pixi-version }}
@@ -56,11 +60,10 @@ jobs:
       - uses: Parcels-code/pixi-lock/create-and-cache@1fab4c17af8243f6ca1321bc941cf2325f46c05d # v0.1.1
         id: pixi-lock
         with:
-          manifest-path: "ci/nightly/pixi.toml"
+          manifest-path: ${{ env.MANIFEST_PATH }}
           hash-files: |
             pyproject.toml
-            pixi.toml
-            ci/nightly/pixi.toml
+            ${{ env.MANIFEST_PATH }}
 
   tests:
     name: upstream-dev
@@ -81,7 +84,7 @@ jobs:
           fetch-depth: 0 # Fetch all history for all branches and tags
           persist-credentials: false
 
-      - uses: Parcels-code/pixi-lock/restore@38495788b79a5ff26009aecc15daa9a8310b8832 # v0.1.0
+      - uses: Parcels-code/pixi-lock/restore@1fab4c17af8243f6ca1321bc941cf2325f46c05d # v0.1.1
         with:
           cache-key: ${{ needs.cache-pixi-lock.outputs.cache-key }}
           manifest-path: ${{ env.MANIFEST_PATH }}

--- a/ci/nightly/pixi.toml
+++ b/ci/nightly/pixi.toml
@@ -1,0 +1,46 @@
+[workspace]
+channels = ["conda-forge"]
+platforms = ["linux-64"]
+
+[dependencies]
+python = "3.14.*"
+pyproj = "*"
+arro3-core = "*"
+matplotlib-base = "*"
+rust = "*"
+pytest-reportlog = "*"
+pooch = "*"
+
+[pypi-options.dependency-overrides]
+numpy = { version = "*", index = "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" }
+pandas = { version = "*", index = "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" }
+xarray = { version = "*", index = "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" }
+pyarrow = { version = "*", index = "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" }
+
+[pypi-dependencies]
+xdggs = { path = "../..", editable = true }
+xarray = "*"
+numpy = "*"
+pandas = "*"
+pyarrow = "*"
+h3ronpy = { git = "git+https://github.com/nmandery/h3ronpy.git", subdirectory = "h3ronpy" }
+cdshealpix = { git = "git+https://github.com/cds-astro/cds-healpix-python.git" }
+healpix-geo = { git = "git+https://github.com/eopf-dggs/healpix-geo.git", subdirectory = "python/healpix-geo" }
+astropy = { git = "git+https://github.com/astropy/astropy.git" }
+lonboard = { git = "git+https://github.com/developmentseed/lonboard.git" }
+
+[feature.tests.dependencies]
+pytest = "*"
+pytest-cov = "*"
+pytest-xdist = "*"
+hypothesis = "*"
+geoarrow-pyarrow = "*"
+shapely = ">=2.1.1,<3"
+dask = ">=2025.7.0"
+
+[feature.tests.tasks]
+tests = { cmd = "pytest -n 0 auto --cov=xdggs", cwd = "../.." }
+
+
+[environments]
+nightly = ["tests"]

--- a/ci/nightly/pixi.toml
+++ b/ci/nightly/pixi.toml
@@ -27,7 +27,7 @@ h3ronpy = { git = "git+https://github.com/nmandery/h3ronpy.git", subdirectory = 
 cdshealpix = { git = "git+https://github.com/cds-astro/cds-healpix-python.git" }
 healpix-geo = { git = "git+https://github.com/eopf-dggs/healpix-geo.git", subdirectory = "python/healpix-geo" }
 astropy = { git = "git+https://github.com/astropy/astropy.git" }
-lonboard = { git = "git+https://github.com/developmentseed/lonboard.git" }
+lonboard = "*"
 
 [feature.tests.dependencies]
 pytest = "*"

--- a/ci/nightly/pixi.toml
+++ b/ci/nightly/pixi.toml
@@ -10,6 +10,9 @@ matplotlib-base = "*"
 rust = "*"
 pytest-reportlog = "*"
 pooch = "*"
+h5netcdf = "*"
+hdf5 = "=2.1.0"
+h5py = "=3.16.0"
 
 [pypi-options.dependency-overrides]
 numpy = { version = "*", index = "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" }

--- a/ci/nightly/pixi.toml
+++ b/ci/nightly/pixi.toml
@@ -19,6 +19,7 @@ numpy = { version = "*", index = "https://pypi.anaconda.org/scientific-python-ni
 pandas = { version = "*", index = "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" }
 xarray = { version = "*", index = "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" }
 pyarrow = { version = "*", index = "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" }
+anywidget = ">=0.11.0"
 
 [pypi-dependencies]
 xdggs = { path = "../..", editable = true }

--- a/ci/nightly/pixi.toml
+++ b/ci/nightly/pixi.toml
@@ -30,7 +30,7 @@ h3ronpy = { git = "git+https://github.com/nmandery/h3ronpy.git", subdirectory = 
 cdshealpix = { git = "git+https://github.com/cds-astro/cds-healpix-python.git" }
 healpix-geo = { git = "git+https://github.com/eopf-dggs/healpix-geo.git", subdirectory = "python/healpix-geo" }
 astropy = { git = "git+https://github.com/astropy/astropy.git" }
-lonboard = "*"
+lonboard = ">=0.14.0"
 
 [feature.tests.dependencies]
 pytest = "*"

--- a/ci/nightly/pixi.toml
+++ b/ci/nightly/pixi.toml
@@ -39,7 +39,7 @@ shapely = ">=2.1.1,<3"
 dask = ">=2025.7.0"
 
 [feature.tests.tasks]
-tests = { cmd = "pytest -n 0 auto --cov=xdggs", cwd = "../.." }
+tests = { cmd = "pytest -n auto --cov=xdggs", cwd = "../.." }
 
 
 [environments]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,7 +52,7 @@ templates_path = ["_templates", sphinx_autosummary_accessors.templates_path]
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ["_build", "directory"]
+exclude_patterns = ["_build", "directory", "jupyter_execute"]
 
 ## Github Buttons
 html_theme_options = {

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -32,7 +32,7 @@ pip install .
 `xdggs` is experimental and thus will switch to newer versions of dependencies if there's significant benefit.
 ```
 
-Otherwise, it will follow a rolling release policy similar to {ref}`xarray:/getting-started-guide/installing.rst#minimum-dependency-versions`:
+Otherwise, it will follow a rolling release policy similar to {ref}`xarray:mindeps_policy`:
 
 - **Python**: 30 months
 - **numpy**: 12 months

--- a/pixi.toml
+++ b/pixi.toml
@@ -53,6 +53,7 @@ dask = ">=2025.7.0"
 
 [feature.tests.tasks]
 tests = { cmd = "pytest -n auto --cov=xdggs", cwd = ".", default-environment = "default" }
+doctests = { cmd = "pytest --doctest-modules xdggs --ignore xdggs/tests", cwd = "." }
 
 [feature.ci-py311.dependencies]
 python = "3.11.*"

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,28 +1,45 @@
 [workspace]
 channels = ["conda-forge"]
 platforms = ["linux-64", "win-64", "osx-arm64"]
+preview = ["pixi-build"]
 
-[pypi-dependencies]
-xdggs = { path = ".", editable = true }
+[package]
+name = "xdggs"
+version = "9999.0.0"
+
+[package.build]
+backend = { name = "pixi-build-python", version = "0.*", channels = [
+  "https://prefix.dev/conda-forge",
+] }
+config = { noarch = true }
+
+[package.host-dependencies]
+python = "*"
+hatchling = "*"
+
+[package.run-dependencies]
+python = ">=3.12"
+xarray = ">=2025.08.0"
+numpy = ">=2.2"
+h3ronpy = ">=0.22.0"
+lonboard = ">=0.14.0"
+healpix-geo = ">=0.2.1"
+arro3-core = "*"
+pyproj = "*"
+pooch = "*"
+h5netcdf = "*"
+matplotlib-base = ">=3.10.5"
 
 [tasks]
 
 [dependencies]
-xarray = ">=2025.08.0"
+xdggs = { path = "." }
 cdshealpix = ">=0.7.1"
-h3ronpy = ">=0.22.0"
-lonboard = ">=0.9.3"
-pyproj = ">=3.3"
-matplotlib-base = ">=3.10.5"
-arro3-core = ">=0.4.0"
-pooch = ">=1.8.2"
-healpix-geo = ">=0.2.1"
 
 [feature.tests.dependencies]
 pytest = "*"
 pytest-cov = "*"
 pytest-xdist = "*"
-h5netcdf = "*"
 netcdf4 = "*"
 hypothesis = "*"
 geoarrow-pyarrow = "*"

--- a/pixi.toml
+++ b/pixi.toml
@@ -2,9 +2,6 @@
 channels = ["conda-forge"]
 platforms = ["linux-64", "win-64", "osx-arm64"]
 
-[system-requirements]
-libc = { family = "glibc", version = "2.34" }
-
 [pypi-dependencies]
 xdggs = { path = ".", editable = true }
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -103,6 +103,7 @@ zarr = ">=3.1.5"
 cf-xarray = ">=0.11.1"
 marimo = ">=0.23.16,<0.24"
 watchfiles = ">=1.1.0"
+pytest-accept = ">=0.2.3,<0.3"
 
 [feature.ci.dependencies]
 python = "*"

--- a/pixi.toml
+++ b/pixi.toml
@@ -29,6 +29,9 @@ arro3-core = "*"
 pyproj = "*"
 pooch = "*"
 h5netcdf = "*"
+# pin hdf5 and h5py to avoid errors in the docs
+hdf5 = "=2.1.0"
+h5py = "=3.16.0"
 matplotlib-base = ">=3.10.5"
 
 [tasks]

--- a/pixi.toml
+++ b/pixi.toml
@@ -16,7 +16,7 @@ pyproj = ">=3.3"
 matplotlib-base = ">=3.10.5"
 arro3-core = ">=0.4.0"
 pooch = ">=1.8.2"
-healpix-geo = ">=0.0.9"
+healpix-geo = ">=0.2.1"
 
 [feature.tests.dependencies]
 pytest = "*"

--- a/pixi.toml
+++ b/pixi.toml
@@ -9,16 +9,17 @@ version = "9999.0.0"
 
 [package.build]
 backend = { name = "pixi-build-python", version = "0.*", channels = [
-  "https://prefix.dev/conda-forge",
+  "conda-forge",
 ] }
 config = { noarch = true }
 
 [package.host-dependencies]
 python = "*"
 hatchling = "*"
+hatch-vcs = "*"
 
 [package.run-dependencies]
-python = ">=3.12"
+python = ">=3.11"
 xarray = ">=2025.08.0"
 numpy = ">=2.2"
 h3ronpy = ">=0.22.0"
@@ -48,33 +49,6 @@ dask = ">=2025.7.0"
 
 [feature.tests.tasks]
 tests = { cmd = "pytest -n auto --cov=xdggs", cwd = ".", default-environment = "default" }
-
-[feature.nightly.pypi-options.dependency-overrides]
-numpy = { version = "*", index = "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" }
-pandas = { version = "*", index = "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" }
-xarray = { version = "*", index = "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" }
-pyarrow = { version = "*", index = "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" }
-
-[feature.nightly.target.unix.pypi-dependencies]
-xdggs = { path = ".", editable = true }
-xarray = "*"
-numpy = "*"
-pandas = "*"
-pyarrow = "*"
-h3ronpy = { git = "git+https://github.com/nmandery/h3ronpy.git", subdirectory = "h3ronpy" }
-cdshealpix = { git = "git+https://github.com/cds-astro/cds-healpix-python.git" }
-healpix-geo = { git = "git+https://github.com/eopf-dggs/healpix-geo.git", subdirectory = "python/healpix-geo" }
-astropy = { git = "git+https://github.com/astropy/astropy.git" }
-
-[feature.nightly.target.unix.dependencies]
-lonboard = ">=0.11.1"
-pyproj = ">=3.7.2"
-matplotlib-base = ">=3.10.5"
-arro3-core = ">=0.6.1"
-pooch = ">=1.8.2"
-rust = ">=1.89.0"
-python = "3.13.*"
-pytest-reportlog = "*"
 
 [feature.ci-py311.dependencies]
 python = "3.11.*"
@@ -123,14 +97,16 @@ h5netcdf = ">=1.7.3"
 zarr = ">=3.1.5"
 cf-xarray = ">=0.11.1"
 
+[feature.ci.dependencies]
+python = "*"
+
+[feature.ci.tasks]
+nightly-tests = { cmd = "pixi run --manifest-path ci/nightly/pixi.toml tests", cwd = "." }
+
 [environments]
-nightly = { features = [
-  "tests",
-  "nightly",
-  "ci-py313",
-], no-default-feature = true }
 ci-py311 = { features = ["tests", "ci-py311"] }
 ci-py312 = { features = ["tests", "ci-py312"] }
 ci-py313 = { features = ["tests", "ci-py313"] }
 docs = { features = ["docs"] }
 default = { features = ["tests", "dev"] }
+ci = { features = ["ci"], no-default-feature = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
   "matplotlib",
   "arro3-core>=0.4.0",
   "pooch",
+  "h5netcdf",
 ]
 dynamic = ["version"]
 

--- a/xdggs/accessor.py
+++ b/xdggs/accessor.py
@@ -82,6 +82,39 @@ class DGGSAccessor:
         -------
         obj : xarray.DataArray or xarray.Dataset
             The object with a DGGS index on the cell id coordinate.
+
+        Examples
+        --------
+        >>> import xdggs
+        >>> import xarray as xr
+        >>> import numpy as np
+
+        Dataset following the xdggs convention:
+
+        >>> ds = xr.Dataset(
+        ...     {"a": ("cells", list("abcdefghijkl"))},
+        ...     coords={
+        ...         "cell_ids": (
+        ...             "cells",
+        ...             np.arange(12, dtype="uint64"),
+        ...             {
+        ...                 "grid_name": "healpix",
+        ...                 "level": 0,
+        ...                 "indexing_scheme": "nested",
+        ...             },
+        ...         )
+        ...     },
+        ... )
+        >>> ds.dggs.decode()
+        <xarray.Dataset> Size: 144B
+        Dimensions:   (cells: 12)
+        Coordinates:
+          * cell_ids  (cells) uint64 96B 0 1 2 3 4 5 6 7 8 9 10 11
+        Dimensions without coordinates: cells
+        Data variables:
+            a         (cells) <U1 48B 'a' 'b' 'c' 'd' 'e' 'f' 'g' 'h' 'i' 'j' 'k' 'l'
+        Indexes:
+            cell_ids  HealpixIndex(level=0, indexing_scheme=nested, kind=pandas)
         """
         return conventions.decode(
             self._obj,


### PR DESCRIPTION
This changes the pixi setup to use `pixi-build` rather than editable installs using `pypi-dependencies`, and moves the entire nightly env to a different file, to avoid having to recompile the nightly deps on every relock.

Also adds a doctests CI job, and fixes some of the failing CI:
- link to `xarray`'s policy using the existing label