### PR TITLE
drop support for python 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
 
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        env: ["ci-py311", "ci-py312", "ci-py313"]
+        env: ["ci-py312", "ci-py313"]
 
     steps:
       - name: Clone repository

--- a/pixi.toml
+++ b/pixi.toml
@@ -19,7 +19,7 @@ hatchling = "*"
 hatch-vcs = "*"
 
 [package.run-dependencies]
-python = ">=3.11"
+python = ">=3.12"
 xarray = ">=2025.08.0"
 numpy = ">=2.2"
 h3ronpy = ">=0.22.0"
@@ -54,9 +54,6 @@ dask = ">=2025.7.0"
 [feature.tests.tasks]
 tests = { cmd = "pytest -n auto --cov=xdggs", cwd = ".", default-environment = "default" }
 doctests = { cmd = "pytest --doctest-modules xdggs --ignore xdggs/tests", cwd = "." }
-
-[feature.ci-py311.dependencies]
-python = "3.11.*"
 
 [feature.ci-py312.dependencies]
 python = "3.12.*"
@@ -112,7 +109,6 @@ python = "*"
 nightly-tests = { cmd = "pixi run --manifest-path ci/nightly/pixi.toml tests", cwd = "." }
 
 [environments]
-ci-py311 = { features = ["tests", "ci-py311"] }
 ci-py312 = { features = ["tests", "ci-py312"] }
 ci-py313 = { features = ["tests", "ci-py313"] }
 docs = { features = ["docs"] }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,12 +16,11 @@ classifiers = [
   "License :: OSI Approved :: Apache Software License",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Topic :: Scientific/Engineering :: GIS",
 ]
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 dependencies = [
   "xarray",
   "numpy>=2.0",


### PR DESCRIPTION
Python 3.11 will reach its official EOL in October 2027 and has been receiving security fixes for a while now. Our policy (aligned with Scientific Python / xarray) allows dropping since April this year.