### PR TITLE
serialize and deserialize compressed indexes

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,7 +6,10 @@
 - Properly decode ellipsoids for the CF convention ({pull}`228`)
 - Rewrite the map widgets using `anywidget` ({pull}`248`)
 - Resolve ellipsoid names on user input ({pull}`257`)
+- Support the ellipsoids for the healpix MOC index ({pull}`258`)
 - Lazy coordinates for the healpix MOC index ({pull}`259`)
+- Support serializing indexes to zarr with compressed coordinates ({pull}`262`
+- Use `H3HexagonLayer` to visualize H3 data ({pull}`263`)
 
 ## 0.6.0 (2026-02-05)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
   "xarray",
   "numpy>=2.0",
   "cdshealpix",
-  "healpix-geo>=0.0.9",
+  "healpix-geo>=0.3.0",
   "h3ronpy",
   "lonboard>=0.9.3",
   "pyproj>=3.3",

--- a/xdggs/conventions/__init__.py
+++ b/xdggs/conventions/__init__.py
@@ -145,7 +145,7 @@ def encode(
     if converter is None:
         raise ValueError(f"unknown convention: {convention}")
 
-    return call_on_dataset(converter.encode, obj)
+    return call_on_dataset(converter.encode, obj, encoding=encoding)
 
 
 __all__ = ["register_convention", "detect_decoder", "DecoderError", "Convention"]

--- a/xdggs/conventions/base.py
+++ b/xdggs/conventions/base.py
@@ -1,12 +1,37 @@
 from collections.abc import Hashable
-from typing import Any
+from typing import Any, ClassVar, Literal
 
 import xarray as xr
 
 from xdggs.grid import DGGSInfo
+from xdggs.typing import TranslationTable
+
+
+def invert_translation_table(mapping: TranslationTable) -> TranslationTable:
+    return dict(
+        (
+            (value, key)
+            if isinstance(value, str)
+            else (key, invert_translation_table(value))
+        )
+        for key, value in mapping.items()
+    )
 
 
 class Convention:
+    translation_table: ClassVar[TranslationTable]
+
+    def _create_translation_table(
+        self, direction: Literal["xdggs", "self"]
+    ) -> TranslationTable:
+        match direction:
+            case "xdggs":
+                return self.translation_table
+            case "self":
+                return invert_translation_table(self.translation_table)
+            case _:
+                raise ValueError(f"unknown direction: {direction}")
+
     def decode(
         self,
         obj: xr.Dataset,

--- a/xdggs/conventions/base.py
+++ b/xdggs/conventions/base.py
@@ -18,6 +18,21 @@ def invert_translation_table(mapping: TranslationTable) -> TranslationTable:
     )
 
 
+def translate_metadata_keys(mapping: dict[str, Any], table: TranslationTable):
+    def _translate(key, value, table):
+        replacement = table.get(key, key)
+        if isinstance(replacement, str):
+            return replacement, value
+
+        renamed_object = {
+            _translate(subkey, subvalue, replacement)
+            for subkey, subvalue in value.items()
+        }
+        return key, renamed_object
+
+    return dict(_translate(key, value, table) for key, value in mapping.items())
+
+
 class Convention:
     translation_table: ClassVar[TranslationTable]
 

--- a/xdggs/conventions/zarr.py
+++ b/xdggs/conventions/zarr.py
@@ -4,26 +4,11 @@ from typing import Any, ClassVar, TypedDict
 
 import xarray as xr
 
-from xdggs.conventions.base import Convention
+from xdggs.conventions.base import Convention, translate_metadata_keys
 from xdggs.conventions.errors import DecoderError
 from xdggs.conventions.registry import register_convention
 from xdggs.typing import TranslationTable
 from xdggs.utils import GRID_REGISTRY
-
-
-def translate_metadata_keys(mapping: dict[str, Any], table: TranslationTable):
-    def _translate(key, value, table):
-        replacement = table.get(key, key)
-        if isinstance(replacement, str):
-            return replacement, value
-
-        renamed_object = {
-            _translate(subkey, subvalue, replacement)
-            for subkey, subvalue in value.items()
-        }
-        return key, renamed_object
-
-    return dict(_translate(key, value, table) for key, value in mapping.items())
 
 
 def extract_convention_declaration(

--- a/xdggs/conventions/zarr.py
+++ b/xdggs/conventions/zarr.py
@@ -168,6 +168,9 @@ class Zarr(Convention):
         encoded : xr.Dataset
             The encoded dataset.
         """
+        if encoding is None:
+            encoding = {}
+
         grid_info = self.translate_metadata(
             ds.dggs.grid_info.to_dict(), direction="inverse"
         )
@@ -186,7 +189,7 @@ class Zarr(Convention):
             "spatial_dimension": ds.dggs.index._dim,
             "coordinate": coordinate,
             "compression": "none",
-        }
+        } | encoding
 
         result = ds.drop_indexes(coordinate)
         result.attrs["dggs"] = grid_info | additional_metadata

--- a/xdggs/conventions/zarr.py
+++ b/xdggs/conventions/zarr.py
@@ -1,13 +1,29 @@
 import copy
 from collections.abc import Hashable
-from typing import Any, Literal
+from typing import Any, ClassVar, TypedDict
 
 import xarray as xr
 
 from xdggs.conventions.base import Convention
 from xdggs.conventions.errors import DecoderError
 from xdggs.conventions.registry import register_convention
+from xdggs.typing import TranslationTable
 from xdggs.utils import GRID_REGISTRY
+
+
+def translate_metadata_keys(mapping: dict[str, Any], table: TranslationTable):
+    def _translate(key, value, table):
+        replacement = table.get(key, key)
+        if isinstance(replacement, str):
+            return replacement, value
+
+        renamed_object = {
+            _translate(subkey, subvalue, replacement)
+            for subkey, subvalue in value.items()
+        }
+        return key, renamed_object
+
+    return dict(_translate(key, value, table) for key, value in mapping.items())
 
 
 def extract_convention_declaration(
@@ -27,12 +43,24 @@ def extract_convention_declaration(
     return None
 
 
+class ZarrConventionHeader(TypedDict):
+    uuid: str
+    schema_url: str
+    spec_url: str
+    name: str
+    description: str
+
+
 @register_convention("zarr")
 class Zarr(Convention):
-    uuid = "7b255807-140c-42ca-97f6-7a1cfecdbc38"
-    schema_url = "https://raw.githubusercontent.com/zarr-conventions/dggs/refs/tags/v1/schema.json"
-    spec_url = "https://github.com/zarr-conventions/dggs/blob/v1/README.md"
-    convention_metadata = {
+    uuid: ClassVar[str] = "7b255807-140c-42ca-97f6-7a1cfecdbc38"
+    schema_url: ClassVar[str] = (
+        "https://raw.githubusercontent.com/zarr-conventions/dggs/refs/tags/v1/schema.json"
+    )
+    spec_url: ClassVar[str] = (
+        "https://github.com/zarr-conventions/dggs/blob/v1/README.md"
+    )
+    convention_metadata: ClassVar[ZarrConventionHeader] = {
         "uuid": uuid,
         "schema_url": schema_url,
         "spec_url": spec_url,
@@ -40,21 +68,14 @@ class Zarr(Convention):
         "description": "Discrete Global Grid Systems convention for zarr",
     }
 
-    def translate_metadata(
-        self,
-        metadata: dict[str, Any],
-        direction: Literal["forward", "inverse"] = "forward",
-    ) -> dict[str, Any]:
-        key_translations = {
-            "name": "grid_name",
-            "refinement_level": "level",
-        }
-        if direction == "inverse":
-            key_translations = {v: k for k, v in key_translations.items()}
-
-        return {
-            key_translations.get(key, key): value for key, value in metadata.items()
-        }
+    translation_table: ClassVar[TranslationTable] = {
+        "refinement_level": "level",
+        "name": "grid_name",
+        "ellipsoid": {
+            "semi_major_axis": "semimajor_axis",
+            "semi_minor_axis": "semiminor_axis",
+        },
+    }
 
     def decode(
         self,
@@ -119,7 +140,8 @@ class Zarr(Convention):
             variables_to_drop.append(coordinate)
 
         # construct index
-        metadata_ = self.translate_metadata(metadata)
+        translation_table = self._create_translation_table(direction="xdggs")
+        metadata_ = translate_metadata_keys(metadata, translation_table)
 
         var = ds.variables[coordinate].copy(deep=False)
         var.attrs = metadata_
@@ -171,32 +193,38 @@ class Zarr(Convention):
         if encoding is None:
             encoding = {}
 
-        grid_info = self.translate_metadata(
-            ds.dggs.grid_info.to_dict(), direction="inverse"
-        )
-
-        # encoding contains:
-        # - compression type (ignored for now)
-
-        # additional keys:
-        # - coordinate
-        # - spatial_dimension
-        # - compression
-
+        # prepare the output dataset
         index = ds.dggs.index
-        coordinate = index._name
+        coordinate = index.name
 
+        coords = index.serialize(encoding=encoding)
+        result = ds.drop_indexes(coordinate).drop_vars(coordinate).assign_coords(coords)
+
+        # grid metadata
+        translation_table = self._create_translation_table(direction="self")
+        raw_grid_metadata = index.grid_info.to_dict()
+        grid_metadata = translate_metadata_keys(raw_grid_metadata, translation_table)
+
+        # additional metadata
+        variables = coords.variables
+        if len(variables) != 1:
+            raise ValueError(
+                f"expected exactly one coordinate while encoding, but got {len(variables)}."
+                " This most likely a problem with the implementation of the index. Please open an issue."
+            )
+        coord_name, coord = next(iter(variables.items()))
+        for key in raw_grid_metadata:
+            coord.attrs.pop(key, None)
+
+        compression = coord.attrs.pop("compression", "none")
         additional_metadata = {
-            "spatial_dimension": ds.dggs.index._dim,
-            "coordinate": coordinate,
-            "compression": "none",
-        } | encoding
+            "coordinate": coord_name,
+            "compression": compression,
+            "spatial_dimension": index._dim,
+        }
 
-        result = ds.drop_indexes(coordinate).assign_coords(
-            index.serialize(overrides=encoding)
-        )
-
-        result.attrs["dggs"] = grid_info | additional_metadata
+        # assign the metadata
+        result.attrs["dggs"] = grid_metadata | additional_metadata
         conventions = result.attrs.setdefault("zarr_conventions", [])
         conventions.append(self.convention_metadata)
 

--- a/xdggs/conventions/zarr.py
+++ b/xdggs/conventions/zarr.py
@@ -183,7 +183,8 @@ class Zarr(Convention):
         # - spatial_dimension
         # - compression
 
-        coordinate = ds.dggs.index._name
+        index = ds.dggs.index
+        coordinate = index._name
 
         additional_metadata = {
             "spatial_dimension": ds.dggs.index._dim,
@@ -191,7 +192,10 @@ class Zarr(Convention):
             "compression": "none",
         } | encoding
 
-        result = ds.drop_indexes(coordinate)
+        result = ds.drop_indexes(coordinate).assign_coords(
+            index.serialize(overrides=encoding)
+        )
+
         result.attrs["dggs"] = grid_info | additional_metadata
         conventions = result.attrs.setdefault("zarr_conventions", [])
         conventions.append(self.convention_metadata)

--- a/xdggs/conventions/zarr.py
+++ b/xdggs/conventions/zarr.py
@@ -111,11 +111,9 @@ class Zarr(Convention):
             raise NotImplementedError("missing coordinate is not supported for now")
 
         # optional, but required to be `"none"` for now
-        compression = metadata.pop("compression", None)
+        compression = metadata.pop("compression", "none")
         if compression != "none":
-            raise NotImplementedError(
-                "compressed coordinates are not supported for now"
-            )
+            index_options["compression"] = compression
 
         # construct index
         metadata_ = self.translate_metadata(metadata)

--- a/xdggs/conventions/zarr.py
+++ b/xdggs/conventions/zarr.py
@@ -112,8 +112,11 @@ class Zarr(Convention):
 
         # optional, but required to be `"none"` for now
         compression = metadata.pop("compression", "none")
+        variables_to_drop = []
         if compression != "none":
             index_options["compression"] = compression
+            index_options["dim"] = spatial_dimension
+            variables_to_drop.append(coordinate)
 
         # construct index
         metadata_ = self.translate_metadata(metadata)
@@ -126,8 +129,10 @@ class Zarr(Convention):
         index_cls = GRID_REGISTRY[grid_name]
         index = index_cls.from_variables({name: var}, options=index_options)
 
-        new_ds = ds.assign_coords(xr.Coordinates.from_xindex(index)).assign_attrs(
-            copy.deepcopy(ds.attrs)
+        new_ds = (
+            ds.assign_coords(xr.Coordinates.from_xindex(index))
+            .drop_vars(variables_to_drop)
+            .assign_attrs(copy.deepcopy(ds.attrs))
         )
         # remove redundant attrs
         new_ds.attrs.pop("dggs", None)

--- a/xdggs/healpix/grid_info.py
+++ b/xdggs/healpix/grid_info.py
@@ -1,6 +1,6 @@
 import json
 from dataclasses import dataclass
-from typing import Any, ClassVar, Literal, Self
+from typing import Any, ClassVar, Literal, Self, TypeVar
 
 import numpy as np
 
@@ -14,6 +14,8 @@ from xdggs.ellipsoid import (
 from xdggs.grid import DGGSInfo, translate_parameters
 from xdggs.itertools import identity
 from xdggs.utils import ignore_parameters
+
+T = TypeVar("T")
 
 
 def _serialize_ellipsoid(
@@ -118,6 +120,8 @@ class HealpixInfo(DGGSInfo):
         The reference ellipsoid. If not passed, a sphere is assumed.
     """
 
+    name: ClassVar[str] = "healpix"
+
     level: int | None
     """int or None : The hierarchical level of the grid"""
 
@@ -169,7 +173,7 @@ class HealpixInfo(DGGSInfo):
             return self.indexing_scheme == "nested"
 
     @classmethod
-    def from_dict[T](cls: type[T], mapping: dict[str, Any]) -> T:
+    def from_dict(cls: type[T], mapping: dict[str, Any]) -> T:
         """construct a `HealpixInfo` object from a mapping of attributes
 
         Parameters
@@ -225,7 +229,7 @@ class HealpixInfo(DGGSInfo):
             optional_values["ellipsoid"] = _serialize_ellipsoid(self.ellipsoid)
 
         return {
-            "grid_name": "healpix",
+            "grid_name": self.name,
             "level": self.level,
             "indexing_scheme": self.indexing_scheme,
         } | optional_values

--- a/xdggs/healpix/index.py
+++ b/xdggs/healpix/index.py
@@ -67,11 +67,14 @@ class HealpixIndex(DGGSIndex):
         *,
         options: Mapping[str, Any],
     ) -> "HealpixIndex":
-        name, var, dim = _extract_cell_id_variable(variables)
+        name, var, var_dim = _extract_cell_id_variable(variables)
+
+        options_ = dict(options)
+        dim = options_.pop("dim", var_dim)
 
         grid_info = HealpixInfo.from_dict(var.attrs)
 
-        return cls(var.data, dim=dim, name=name, grid_info=grid_info, **options)
+        return cls(var.data, dim=dim, name=name, grid_info=grid_info, **options_)
 
     def _replace(self, new_index: xr.Index):
         return type(self)(

--- a/xdggs/healpix/index.py
+++ b/xdggs/healpix/index.py
@@ -85,6 +85,21 @@ class HealpixIndex(DGGSIndex):
             index_kind=self._kind,
         )
 
+    def serialize(self, *, overrides: dict[str, Any] | None = None) -> xr.Coordinates:
+        """Serialize the index into coordinates and metadata
+
+        Parameters
+        ----------
+        overrides : mapping of str to object, optional
+            Overrides for the index serialization.
+        """
+        if isinstance(self._index, PandasIndex):
+            variables = self._index.create_variables()
+
+            return xr.Coordinates(variables, indexes={})
+        else:
+            return self._index.serialize(overrides=overrides)
+
     @property
     def grid_info(self) -> HealpixInfo:
         return self._grid

--- a/xdggs/healpix/index.py
+++ b/xdggs/healpix/index.py
@@ -8,6 +8,7 @@ from xdggs.grid import DGGSInfo
 from xdggs.healpix.grid_info import HealpixInfo
 from xdggs.healpix.moc_index import HealpixMocIndex
 from xdggs.index import DGGSIndex
+from xdggs.typing import Compression
 from xdggs.utils import _extract_cell_id_variable, register_dggs
 
 
@@ -16,16 +17,40 @@ class HealpixIndex(DGGSIndex):
     def __init__(
         self,
         cell_ids: Any | xr.Index,
-        dim: str,
-        name: str,
-        grid_info: DGGSInfo,
+        *,
+        dim: str | None = None,
+        name: str | None = None,
+        grid_info: DGGSInfo | None = None,
         index_kind: str = "pandas",
+        compression: Compression = "none",
     ):
-        if not isinstance(grid_info, HealpixInfo):
-            raise ValueError(f"grid info object has an invalid type: {type(grid_info)}")
+        if isinstance(cell_ids, HealpixMocIndex):
+            # all information already on the moc index
+            self._index = cell_ids
+
+            self._grid_info = grid_info
+            self._dim = cell_ids.dim
+            self._name = cell_ids.name
+
+            return
+
+        if self._dim is None:
+            raise TypeError(
+                "missing required parameter when creating a healpix index from cell ids: 'dim'"
+            )
+        if self._name is None:
+            raise TypeError(
+                "missing required parameter when creating a healpix index from cell ids: 'name'"
+            )
 
         self._dim = dim
         self._name = name
+
+        if not isinstance(grid_info, HealpixInfo):
+            raise ValueError(f"grid info object has an invalid type: {type(grid_info)}")
+
+        if compression != "none" and index_kind == "pandas":
+            raise ValueError("the pandas backend does not support compressed cell ids")
 
         if isinstance(cell_ids, xr.Index):
             self._index = cell_ids
@@ -34,7 +59,11 @@ class HealpixIndex(DGGSIndex):
             self._index.index.name = name
         elif index_kind == "moc":
             self._index = HealpixMocIndex.from_array(
-                cell_ids, dim=dim, grid_info=grid_info, name=name
+                cell_ids,
+                dim=dim,
+                grid_info=grid_info,
+                name=name,
+                compression=compression,
             )
         self._kind = index_kind
 

--- a/xdggs/healpix/index.py
+++ b/xdggs/healpix/index.py
@@ -85,7 +85,7 @@ class HealpixIndex(DGGSIndex):
             index_kind=self._kind,
         )
 
-    def serialize(self, *, overrides: dict[str, Any] | None = None) -> xr.Coordinates:
+    def serialize(self, *, encoding: dict[str, Any] | None = None) -> xr.Coordinates:
         """Serialize the index into coordinates and metadata
 
         Parameters
@@ -93,16 +93,22 @@ class HealpixIndex(DGGSIndex):
         overrides : mapping of str to object, optional
             Overrides for the index serialization.
         """
-        if isinstance(self._index, PandasIndex):
-            variables = self._index.create_variables()
-
-            return xr.Coordinates(variables, indexes={})
+        if self._kind == "pandas":
+            return super().serialize(encoding=encoding)
         else:
-            return self._index.serialize(overrides=overrides)
+            return self._index.serialize(encoding=encoding)
 
     @property
     def grid_info(self) -> HealpixInfo:
         return self._grid
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def dim(self) -> str:
+        return self._dim
 
     def __repr__(self):
         return "\n".join(

--- a/xdggs/healpix/index.py
+++ b/xdggs/healpix/index.py
@@ -8,7 +8,6 @@ from xdggs.grid import DGGSInfo
 from xdggs.healpix.grid_info import HealpixInfo
 from xdggs.healpix.moc_index import HealpixMocIndex
 from xdggs.index import DGGSIndex
-from xdggs.typing import Compression
 from xdggs.utils import _extract_cell_id_variable, register_dggs
 
 
@@ -16,41 +15,34 @@ from xdggs.utils import _extract_cell_id_variable, register_dggs
 class HealpixIndex(DGGSIndex):
     def __init__(
         self,
-        cell_ids: Any | xr.Index,
+        cell_ids: Any,
         *,
-        dim: str | None = None,
-        name: str | None = None,
-        grid_info: DGGSInfo | None = None,
-        index_kind: str = "pandas",
-        compression: Compression = "none",
+        dim: str,
+        name: str,
+        grid_info: DGGSInfo,
+        index_kind: str | None = None,
+        **options,
     ):
-        if isinstance(cell_ids, HealpixMocIndex):
-            # all information already on the moc index
-            self._index = cell_ids
-
-            self._grid_info = grid_info
-            self._dim = cell_ids.dim
-            self._name = cell_ids.name
-
-            return
-
-        if self._dim is None:
-            raise TypeError(
-                "missing required parameter when creating a healpix index from cell ids: 'dim'"
-            )
-        if self._name is None:
-            raise TypeError(
-                "missing required parameter when creating a healpix index from cell ids: 'name'"
-            )
-
         self._dim = dim
         self._name = name
+        self._grid = grid_info
 
         if not isinstance(grid_info, HealpixInfo):
             raise ValueError(f"grid info object has an invalid type: {type(grid_info)}")
 
-        if compression != "none" and index_kind == "pandas":
+        if isinstance(cell_ids, HealpixMocIndex):
+            if index_kind not in ("moc", None):
+                raise ValueError(
+                    f"received a moc index instance but index_kind does not match: {index_kind}"
+                )
+            index_kind = "moc"
+        elif index_kind is None:
+            index_kind = "pandas"
+
+        if index_kind == "pandas" and "compression" in options:
             raise ValueError("the pandas backend does not support compressed cell ids")
+
+        self._kind = index_kind
 
         if isinstance(cell_ids, xr.Index):
             self._index = cell_ids
@@ -59,15 +51,8 @@ class HealpixIndex(DGGSIndex):
             self._index.index.name = name
         elif index_kind == "moc":
             self._index = HealpixMocIndex.from_array(
-                cell_ids,
-                dim=dim,
-                grid_info=grid_info,
-                name=name,
-                compression=compression,
+                cell_ids, dim=dim, grid_info=grid_info, name=name, **options
             )
-        self._kind = index_kind
-
-        self._grid = grid_info
 
     def values(self):
         if self._kind == "moc":
@@ -84,15 +69,17 @@ class HealpixIndex(DGGSIndex):
     ) -> "HealpixIndex":
         name, var, dim = _extract_cell_id_variable(variables)
 
-        index_kind = options.pop("index_kind", "pandas")
+        grid_info = HealpixInfo.from_dict(var.attrs)
 
-        grid_info = HealpixInfo.from_dict(var.attrs | options)
-
-        return cls(var.data, dim, name, grid_info, index_kind=index_kind)
+        return cls(var.data, dim=dim, name=name, grid_info=grid_info, **options)
 
     def _replace(self, new_index: xr.Index):
         return type(self)(
-            new_index, self._dim, self._name, self._grid, index_kind=self._kind
+            new_index,
+            dim=self._dim,
+            name=self._name,
+            grid_info=self._grid,
+            index_kind=self._kind,
         )
 
     @property

--- a/xdggs/healpix/moc_index.py
+++ b/xdggs/healpix/moc_index.py
@@ -323,6 +323,35 @@ class HealpixMocIndex(xr.Index):
         return {name: var}
 
     def serialize(self, *, encoding: dict[str, Any] | None = None) -> xr.Coordinates:
+        """serialize the index
+
+        Parameters
+        ----------
+        encoding : dict of str to object, optional
+            Additional serialization settings.
+
+            Supported settings are:
+
+            - ``"compression"``: the type of compression. For supported values see below.
+            - ``"coordinate"``: the name of the encoded coordinate. Defaults depend on the compression type.
+
+            Supported compression types:
+
+            - ``"none"``: to enumerate all cell ids. Uses the indexed coordinate's name by default.
+            - ``"compacted"``: to compact the cell ids to flat or variable sized cell ids in
+              the ``zuniq`` scheme. The default coordinate name is ``"compacted_cell_ids"``.
+              Additional settings:
+
+              - ``"dim"``: The dimension name of the compacted coordinate. Must be different
+                from the index' dimension. The default is ``"compacted_cells"``.
+              - ``"compacted_level"``: the compaction level. If an integer, must be smaller
+                than the data level. If none (the default), compacts to variably-sized cells.
+
+            - ``"ranges"``: to store the connected ranges in ``nested`` scheme at level 29. The default coordinate name is ``"cell_ranges"``. Additional settings:
+
+              - ``"dim"``: The dimension name of the range number. By default, this is ``"range_index"``.
+              - ``"bounds_dim"``: The dimension name of the range bounds. By default, this is ``"range_bounds"``.
+        """
         if encoding is None:
             encoding = {}
 

--- a/xdggs/healpix/moc_index.py
+++ b/xdggs/healpix/moc_index.py
@@ -185,6 +185,11 @@ class HealpixMocIndex(xr.Index):
         """The size of the chunks of the indexed coordinate."""
         return self._chunksizes
 
+    @property
+    def grid_info(self) -> HealpixInfo:
+        """The grid metadata of the index."""
+        return self._grid_info
+
     @classmethod
     def from_array(
         cls, array, *, dim, name, grid_info, compression: Compression = "none"

--- a/xdggs/healpix/moc_index.py
+++ b/xdggs/healpix/moc_index.py
@@ -8,6 +8,8 @@ from xarray.core.indexes import IndexSelResult
 
 from xdggs.healpix.grid_info import HealpixInfo
 from xdggs.healpix.indexing_adapters import MocRangesIndexingAdapter
+from xdggs.itertools import pairwise_tree_reduce
+from xdggs.typing import Compression
 from xdggs.utils import _extract_cell_id_variable
 
 try:
@@ -88,6 +90,46 @@ def extract_chunk(index, slice_):
     return index.isel(slice_).cell_ids()
 
 
+def _create_index_from_array(
+    array, grid_info, compression: Compression
+) -> RangeMOCIndex:
+    ellipsoid = grid_info.ellipsoid
+    if ellipsoid is None:
+        import healpix_geo.ellipsoid
+
+        ellipsoid = healpix_geo.ellipsoid.resolve("sphere")
+
+    if array.size == 12 * 4**grid_info.level:
+        # no need to look at the cell ids
+        return RangeMOCIndex.full_domain(grid_info.level, ellipsoid=ellipsoid)
+
+    create_index_funcs = {
+        "none": RangeMOCIndex.from_cell_ids,
+        "compacted": RangeMOCIndex.from_compacted,
+        "ranges": RangeMOCIndex.from_ranges,
+    }
+    create_index = create_index_funcs.get(compression)
+    if create_index is None:
+        raise ValueError(f"unknown compression scheme: {compression!r}")
+
+    if isinstance(array, dask_array_type):
+        import dask
+
+        indexes = [
+            dask.delayed(create_index)(grid_info.level, chunk, ellipsoid)
+            for chunk in array.astype("uint64").to_delayed().flatten()
+        ]
+        task = pairwise_tree_reduce(dask.delayed(RangeMOCIndex.union), indexes)
+
+        index = dask.compute(task)[0]
+    else:
+        index = create_index(
+            grid_info.level, array.astype("uint64"), ellipsoid=ellipsoid
+        )
+
+    return index
+
+
 # optionally replaces the PandasIndex within HealpixIndex
 class HealpixMocIndex(xr.Index):
     """More efficient index for healpix cell ids based on a MOC
@@ -106,12 +148,22 @@ class HealpixMocIndex(xr.Index):
         The low-level implementation of the index functionality.
     """
 
-    def __init__(self, index, *, dim, name, grid_info, chunksizes):
+    def __init__(
+        self,
+        index,
+        *,
+        dim,
+        name,
+        grid_info,
+        chunksizes,
+        compression: Compression = "none",
+    ):
         self._index = index
         self._dim = dim
         self._grid_info = grid_info
         self._name = name
         self._chunksizes = chunksizes
+        self._compression = compression
 
     @property
     def size(self):
@@ -133,7 +185,9 @@ class HealpixMocIndex(xr.Index):
         return self._chunksizes
 
     @classmethod
-    def from_array(cls, array, *, dim, name, grid_info):
+    def from_array(
+        cls, array, *, dim, name, grid_info, compression: Compression = "none"
+    ):
         """Construct an index from a raw array.
 
         Parameters
@@ -161,33 +215,17 @@ class HealpixMocIndex(xr.Index):
                 "The MOC index currently only supports the 'nested' scheme"
             )
 
-        if array.ndim != 1:
-            raise ValueError("only 1D cell ids are supported")
-
-        ellipsoid = grid_info.ellipsoid
-        if ellipsoid is None:
-            import healpix_geo.ellipsoid
-
-            ellipsoid = healpix_geo.ellipsoid.resolve("sphere")
-
-        if array.size == 12 * 4**grid_info.level:
-            index = RangeMOCIndex.full_domain(grid_info.level)
-        elif isinstance(array, dask_array_type):
-            from functools import reduce
-
-            import dask
-
-            [indexes] = dask.compute(
-                dask.delayed(RangeMOCIndex.from_cell_ids)(
-                    grid_info.level, chunk, ellipsoid=ellipsoid
+        print(compression, array.ndim, array)
+        if compression == "ranges":
+            if array.ndim != 2 or array.shape[1] != 2:
+                raise ValueError(
+                    "the range compressed coordinate must have a shape of (n, 2)"
                 )
-                for chunk in array.astype("uint64").to_delayed()
-            )
-            index = reduce(RangeMOCIndex.union, indexes)
         else:
-            index = RangeMOCIndex.from_cell_ids(
-                grid_info.level, array.astype("uint64"), ellipsoid=ellipsoid
-            )
+            if array.ndim != 1:
+                raise ValueError("only 1D cell ids are supported")
+
+        index = _create_index_from_array(array, grid_info, compression)
 
         chunksizes = {dim: array.chunks[0] if hasattr(array, "chunks") else None}
         return cls(
@@ -221,9 +259,14 @@ class HealpixMocIndex(xr.Index):
             A new Index object.
         """
         name, var, dim = _extract_cell_id_variable(variables)
-        grid_info = HealpixInfo.from_dict(var.attrs | options)
 
-        return cls.from_array(var.data, dim=dim, name=name, grid_info=grid_info)
+        options_ = dict(options)
+        compression = options_.pop("compression", "none")
+        grid_info = HealpixInfo.from_dict(var.attrs | options_)
+
+        return cls.from_array(
+            var.data, dim=dim, name=name, grid_info=grid_info, compression=compression
+        )
 
     def create_variables(
         self, variables: Mapping[Any, xr.Variable] | None = None

--- a/xdggs/healpix/moc_index.py
+++ b/xdggs/healpix/moc_index.py
@@ -321,13 +321,15 @@ class HealpixMocIndex(xr.Index):
         if encoding is None:
             encoding = {}
 
-        coordinate_name = encoding.get("coordinate", self._name)
         compression = encoding.get("compression", self._compression)
         attrs = {"compression": compression}
         match compression:
             case "none":
+                coordinate_name = encoding.get("coordinate", self._name)
                 variable = xr.Variable(self._dim, self._index.cell_ids(), attrs)
             case "compacted":
+                coordinate_name = encoding.get("coordinate", "compacted_cell_ids")
+
                 compacted_level = encoding.get("compacted_level", None)
                 compacted_dim = encoding.get("dim", "compacted_cells")
                 if compacted_level is None:
@@ -340,6 +342,8 @@ class HealpixMocIndex(xr.Index):
 
                 variable = xr.Variable(compacted_dim, cell_ids, attrs)
             case "ranges":
+                coordinate_name = encoding.get("coordinate", "cell_ranges")
+
                 range_dim = encoding.get("dim", "range_index")
                 bounds_dim = encoding.get("bounds_dim", "bounds")
 

--- a/xdggs/healpix/moc_index.py
+++ b/xdggs/healpix/moc_index.py
@@ -1,6 +1,7 @@
 from collections.abc import Hashable, Mapping
 from typing import Any, Self
 
+import healpix_geo
 import numpy as np
 import xarray as xr
 from healpix_geo.nested import RangeMOCIndex
@@ -315,6 +316,39 @@ class HealpixMocIndex(xr.Index):
         var = xr.Variable(self._dim, data, attrs=attrs, encoding=encoding)
 
         return {name: var}
+
+    def serialize(self, *, encoding: dict[str, Any] | None = None) -> xr.Coordinates:
+        if encoding is None:
+            encoding = {}
+
+        coordinate_name = encoding.get("coordinate", self._name)
+        compression = encoding.get("compression", self._compression)
+        attrs = {"compression": compression}
+        match compression:
+            case "none":
+                variable = xr.Variable(self._dim, self._index.cell_ids(), attrs)
+            case "compacted":
+                compacted_level = encoding.get("compacted_level", None)
+                compacted_dim = encoding.get("dim", "compacted_cells")
+                if compacted_level is None:
+                    cell_ids = self._index.compacted_cell_ids()
+                else:
+                    cell_ids = healpix_geo.nested.to_zuniq(
+                        self._index.refine(compacted_level).cell_ids(),
+                        compacted_level,
+                    )
+
+                variable = xr.Variable(compacted_dim, cell_ids, attrs)
+            case "ranges":
+                range_dim = encoding.get("dim", "range_index")
+                bounds_dim = encoding.get("bounds_dim", "bounds")
+
+                ranges = self._index.ranges()
+                variable = xr.Variable((range_dim, bounds_dim), ranges, attrs)
+            case _:
+                raise NotImplementedError(f"unknown compression method: {compression}")
+
+        return xr.Coordinates({coordinate_name: variable}, indexes={})
 
     def isel(self, indexers):
         """Subset the index using positional indexers.

--- a/xdggs/healpix/moc_index.py
+++ b/xdggs/healpix/moc_index.py
@@ -1,5 +1,5 @@
 from collections.abc import Hashable, Mapping
-from typing import Any
+from typing import Any, Self
 
 import numpy as np
 import xarray as xr
@@ -239,6 +239,24 @@ class HealpixMocIndex(xr.Index):
             grid_info=self._grid_info,
             chunksizes=chunksizes,
         )
+
+    def equals(self, other: Self) -> bool:
+        """compare two instances of MOC-based indexes"""
+        if not isinstance(other, type(self)):
+            return False
+
+        if (
+            self._dim != other._dim
+            or self._name != other._name
+            or self._chunksizes != other._chunksizes
+            or self._compression != other._compression
+        ):
+            return False
+        if self._grid_info != other._grid_info:
+            return False
+
+        # until the range index supports comparing directly
+        return np.all(self._index.ranges() == other._index.ranges())
 
     @classmethod
     def from_variables(cls, variables, *, options):

--- a/xdggs/healpix/moc_index.py
+++ b/xdggs/healpix/moc_index.py
@@ -229,7 +229,12 @@ class HealpixMocIndex(xr.Index):
 
         chunksizes = {dim: array.chunks[0] if hasattr(array, "chunks") else None}
         return cls(
-            index, dim=dim, name=name, grid_info=grid_info, chunksizes=chunksizes
+            index,
+            dim=dim,
+            name=name,
+            grid_info=grid_info,
+            chunksizes=chunksizes,
+            compression=compression,
         )
 
     def _replace(self, index, chunksizes):
@@ -323,6 +328,7 @@ class HealpixMocIndex(xr.Index):
 
         compression = encoding.get("compression", self._compression)
         attrs = {"compression": compression}
+
         match compression:
             case "none":
                 coordinate_name = encoding.get("coordinate", self._name)

--- a/xdggs/healpix/moc_index.py
+++ b/xdggs/healpix/moc_index.py
@@ -369,6 +369,11 @@ class HealpixMocIndex(xr.Index):
                 compacted_dim = encoding.get("dim", "compacted_cells")
                 if compacted_level is None:
                     cell_ids = self._index.compacted_cell_ids()
+                elif compacted_level >= self.grid_info.level:
+                    raise ValueError(
+                        "The compaction level must be smaller than the data level."
+                        f" Got: {self.grid_info.level} (data) and {compacted_level} (compaction)."
+                    )
                 else:
                     cell_ids = healpix_geo.nested.to_zuniq(
                         self._index.refine(compacted_level).cell_ids(),

--- a/xdggs/healpix/moc_index.py
+++ b/xdggs/healpix/moc_index.py
@@ -215,7 +215,6 @@ class HealpixMocIndex(xr.Index):
                 "The MOC index currently only supports the 'nested' scheme"
             )
 
-        print(compression, array.ndim, array)
         if compression == "ranges":
             if array.ndim != 2 or array.shape[1] != 2:
                 raise ValueError(

--- a/xdggs/index.py
+++ b/xdggs/index.py
@@ -102,6 +102,9 @@ class DGGSIndex(Index):
     def _replace(self, new_index: PandasIndex):
         raise NotImplementedError()
 
+    def serialize(self, *, encoding: dict[str, Any] | None = None) -> xr.Coordinates:
+        raise NotImplementedError()
+
     def cell_centers(self) -> tuple[np.ndarray, np.ndarray]:
         return self._grid.cell_ids2geographic(self.values())
 

--- a/xdggs/index.py
+++ b/xdggs/index.py
@@ -103,7 +103,26 @@ class DGGSIndex(Index):
         raise NotImplementedError()
 
     def serialize(self, *, encoding: dict[str, Any] | None = None) -> xr.Coordinates:
-        raise NotImplementedError()
+        unknown_encodings = [
+            key for key in encoding if key not in {"compression", "coordinate"}
+        ]
+        if unknown_encodings:
+            raise ValueError(
+                f"Unknown encodings: {', '.join(repr(k) for k in unknown_encodings)}"
+            )
+
+        if encoding.get("compression", "none") != "none":
+            raise ValueError(
+                'This index implementation does not support any compression other than ``"none"``'
+            )
+
+        variables = self._index.create_variables()
+        coords = xr.Coordinates(variables, indexes={})
+
+        coordinate_name = encoding.get("coordinate", self.name)
+        if coordinate_name != self.name:
+            coords = coords.rename_vars({self.name: coordinate_name})
+        return coords
 
     def cell_centers(self) -> tuple[np.ndarray, np.ndarray]:
         return self._grid.cell_ids2geographic(self.values())
@@ -117,3 +136,11 @@ class DGGSIndex(Index):
     @property
     def grid_info(self) -> DGGSInfo:
         return self._grid
+
+    @property
+    def dim(self) -> str:
+        return self._dim
+
+    @property
+    def name(self) -> str:
+        return self._index.index.name

--- a/xdggs/itertools.py
+++ b/xdggs/itertools.py
@@ -1,4 +1,5 @@
 import itertools
+from collections.abc import Callable, Sequence
 
 
 def identity(x):
@@ -7,3 +8,26 @@ def identity(x):
 
 def groupby(iterable, key):
     return itertools.groupby(sorted(iterable, key=key), key=key)
+
+
+def partition(n, iterable, pad=None):
+    iterators = [iter(iterable)] * n
+
+    return itertools.zip_longest(*iterators, fillvalue=pad)
+
+
+def pairwise_tree_reduce[T](func: Callable, values: Sequence[T]) -> T:
+    def reduce(a, b):
+        if b is None:
+            return a
+
+        return func(a, b)
+
+    if len(values) == 0:
+        raise ValueError("must receive at least one value")
+
+    results = list(values)
+    while len(results) > 1:
+        results = [reduce(a, b) for a, b in partition(2, results, pad=None)]
+
+    return results[0]

--- a/xdggs/tests/__init__.py
+++ b/xdggs/tests/__init__.py
@@ -26,6 +26,23 @@ except ImportError:
     has_dask = False
 
 
+try:
+    import healpix_geo
+    from packaging import version
+
+    has_healpix_geo_0_4_1 = version.parse(healpix_geo.__version__) >= version.parse(
+        "0.4.1"
+    )
+except ImportError:
+    has_healpix_geo_0_4_1 = False
+
+
+requires_dask = pytest.mark.skipif(not has_dask, reason="requires dask")
+requires_healpix_geo_0_4_1 = pytest.mark.skipif(
+    not has_healpix_geo_0_4_1, reason="requires healpix-geo >= 0.4.1"
+)
+
+
 # vendored from xarray
 class CountingScheduler:
     """Simple dask scheduler counting the number of computes.
@@ -43,9 +60,6 @@ class CountingScheduler:
                 f"Too many computes. Total: {self.total_computes} > max: {self.max_computes}."
             )
         return dask.get(dsk, keys, **kwargs)
-
-
-requires_dask = pytest.mark.skipif(not has_dask, reason="requires dask")
 
 
 def geoarrow_to_shapely(arr):

--- a/xdggs/tests/__init__.py
+++ b/xdggs/tests/__init__.py
@@ -1,8 +1,10 @@
+import importlib.metadata
 from contextlib import nullcontext
 
 import geoarrow.pyarrow as ga
 import pytest
 import shapely
+from packaging import version
 
 from xdggs.tests.matchers import (  # noqa: F401
     Match,
@@ -26,13 +28,14 @@ except ImportError:
     has_dask = False
 
 
-try:
-    import healpix_geo
-    from packaging import version
+def find_version(module_name: str) -> version.Version:
+    version_ = importlib.metadata.version(module_name)
 
-    has_healpix_geo_0_4_1 = version.parse(healpix_geo.__version__) >= version.parse(
-        "0.4.1"
-    )
+    return version.parse(version_)
+
+
+try:
+    has_healpix_geo_0_4_1 = find_version("healpix_geo") >= version.parse("0.4.1")
 except ImportError:
     has_healpix_geo_0_4_1 = False
 

--- a/xdggs/tests/test_conventions.py
+++ b/xdggs/tests/test_conventions.py
@@ -7,7 +7,6 @@ from xdggs import conventions
 from xdggs.conventions.cf import Cf
 from xdggs.conventions.errors import DecoderError
 from xdggs.conventions.xdggs import Xdggs
-from xdggs.conventions.zarr import Zarr
 from xdggs.tests import assert_indexes_equal
 
 
@@ -233,115 +232,6 @@ class TestCfConvention:
         expected = xr.Coordinates(
             {"crs": crs, name: index_var}, indexes={}
         ).to_dataset()
-
-        encoded = convention.encode(obj)
-
-        # should not modify the original dataset
-        xr.testing.assert_identical(obj, orig)
-
-        xr.testing.assert_identical(encoded, expected)
-        assert_indexes_equal(encoded.xindexes, expected.xindexes)
-
-
-class TestZarrConvention:
-    def translate(self, mapping):
-        translations = {"grid_name": "name", "level": "refinement_level"}
-        return {translations.get(name, name): value for name, value in mapping.items()}
-
-    @pytest.mark.parametrize(
-        ["name", "dim"], [("cell_ids", "cells"), ("zone_ids", "zones")]
-    )
-    @pytest.mark.parametrize(
-        ["grid_info", "cell_ids"],
-        (
-            (
-                {"grid_name": "healpix", "level": 1, "indexing_scheme": "nested"},
-                np.array([3, 6, 9], dtype="uint64"),
-            ),
-            (
-                {"grid_name": "h3", "level": 4},
-                np.array([0x832830FFFFFFFFF], dtype="uint64"),
-            ),
-        ),
-    )
-    def test_decode(self, grid_info, cell_ids, name, dim):
-        convention = Zarr()
-
-        dggs_metadata_object = self.translate(grid_info) | {
-            "spatial_dimension": dim,
-            "coordinate": name,
-            "compression": "none",
-        }
-        metadata = {
-            "zarr_conventions": [convention.convention_metadata],
-            "dggs": dggs_metadata_object,
-        }
-
-        var = xr.Variable(dim, cell_ids)
-        index = xdggs.index.DGGSIndex.from_variables(
-            {name: xr.Variable(dim, cell_ids, grid_info)}, options={}
-        )
-        expected = xr.Coordinates.from_xindex(index).to_dataset()
-
-        obj = xr.Dataset(coords={name: var}, attrs=metadata)
-        orig = obj.copy(deep=True)
-        actual = convention.decode(
-            obj,
-            grid_info=None,
-            name=name,
-            index_options={},
-        )
-        # should not modify the original dataset
-        xr.testing.assert_identical(obj, orig)
-
-        print(obj, actual, expected)
-        xr.testing.assert_identical(actual, expected)
-        assert_indexes_equal(actual[name].xindexes, expected[name].xindexes)
-
-        obj = xr.Dataset(coords={name: (dim, cell_ids)})
-        actual = convention.decode(
-            obj, grid_info=dggs_metadata_object, name=name, index_options={}
-        )
-        xr.testing.assert_identical(actual, expected)
-        assert_indexes_equal(actual[name].xindexes, expected[name].xindexes)
-
-    @pytest.mark.parametrize(
-        ["name", "dim"], [("cell_ids", "cells"), ("zone_ids", "zones")]
-    )
-    @pytest.mark.parametrize(
-        ["grid_info", "cell_ids"],
-        (
-            (
-                {"grid_name": "healpix", "level": 1, "indexing_scheme": "nested"},
-                np.array([3, 6, 9], dtype="uint64"),
-            ),
-            (
-                {"grid_name": "h3", "level": 4},
-                np.array([0x832830FFFFFFFFF], dtype="uint64"),
-            ),
-        ),
-    )
-    def test_encode(self, grid_info, cell_ids, name, dim):
-        convention = Zarr()
-
-        index_cls = xdggs.index.GRID_REGISTRY[grid_info["grid_name"]]
-        var = xr.Variable(dim, cell_ids, grid_info)
-        index = index_cls.from_variables({name: var}, options={})
-
-        obj = xr.Dataset(coords=xr.Coordinates({name: var}, indexes={name: index}))
-        orig = obj.copy(deep=True)
-
-        coord = obj.dggs.coord
-        dggs_metadata_object = self.translate(grid_info) | {
-            "spatial_dimension": coord.dims[0],
-            "coordinate": coord.name,
-            "compression": "none",
-        }
-        metadata = {
-            "zarr_conventions": [convention.convention_metadata],
-            "dggs": dggs_metadata_object,
-        }
-        expected = obj.drop_indexes(coord.name).assign_attrs(metadata)
 
         encoded = convention.encode(obj)
 

--- a/xdggs/tests/test_conventions_zarr.py
+++ b/xdggs/tests/test_conventions_zarr.py
@@ -101,7 +101,7 @@ def test_decode(grid_info, metadata_object, cell_ids, name, dim):
                 "name": "healpix",
                 "refinement_level": 5,
                 "indexing_scheme": "nested",
-                "coordinate": "cell_ranges",
+                "coordinate": "compacted_cell_ids",
                 "spatial_dimension": "cells",
                 "compression": "compacted",
             },
@@ -150,19 +150,21 @@ def test_decode_compression(metadata_object, grid_info, variable):
     ["name", "dim"], [("cell_ids", "cells"), ("zone_ids", "zones")]
 )
 @pytest.mark.parametrize(
-    ["grid_info", "cell_ids"],
+    ["grid_info", "metadata_object", "cell_ids"],
     (
         (
             {"grid_name": "healpix", "level": 1, "indexing_scheme": "nested"},
+            {"name": "healpix", "refinement_level": 1, "indexing_scheme": "nested"},
             np.array([3, 6, 9], dtype="uint64"),
         ),
         (
             {"grid_name": "h3", "level": 4},
+            {"name": "h3", "refinement_level": 4},
             np.array([0x832830FFFFFFFFF], dtype="uint64"),
         ),
     ),
 )
-def test_encode(grid_info, cell_ids, name, dim):
+def test_encode(grid_info, metadata_object, cell_ids, name, dim):
     convention = Zarr()
 
     index_cls = xdggs.index.GRID_REGISTRY[grid_info["grid_name"]]
@@ -173,7 +175,7 @@ def test_encode(grid_info, cell_ids, name, dim):
     orig = obj.copy(deep=True)
 
     coord = obj.dggs.coord
-    dggs_metadata_object = translate(grid_info) | {
+    dggs_metadata_object = metadata_object | {
         "spatial_dimension": coord.dims[0],
         "coordinate": coord.name,
         "compression": "none",
@@ -182,7 +184,7 @@ def test_encode(grid_info, cell_ids, name, dim):
         "zarr_conventions": [convention.convention_metadata],
         "dggs": dggs_metadata_object,
     }
-    expected = obj.drop_indexes(coord.name).assign_attrs(metadata)
+    expected = xr.Dataset(coords={coord.name: (dim, cell_ids)}, attrs=metadata)
 
     encoded = convention.encode(obj)
 

--- a/xdggs/tests/test_conventions_zarr.py
+++ b/xdggs/tests/test_conventions_zarr.py
@@ -1,0 +1,117 @@
+import numpy as np
+import pytest
+import xarray as xr
+
+import xdggs
+from xdggs.conventions import Zarr
+from xdggs.tests import assert_indexes_equal
+
+
+def translate(mapping):
+    translations = {"grid_name": "name", "level": "refinement_level"}
+    return {translations.get(name, name): value for name, value in mapping.items()}
+
+
+@pytest.mark.parametrize(
+    ["name", "dim"], [("cell_ids", "cells"), ("zone_ids", "zones")]
+)
+@pytest.mark.parametrize(
+    ["grid_info", "cell_ids"],
+    (
+        (
+            {"grid_name": "healpix", "level": 1, "indexing_scheme": "nested"},
+            np.array([3, 6, 9], dtype="uint64"),
+        ),
+        (
+            {"grid_name": "h3", "level": 4},
+            np.array([0x832830FFFFFFFFF], dtype="uint64"),
+        ),
+    ),
+)
+def test_decode(grid_info, cell_ids, name, dim):
+    convention = Zarr()
+
+    dggs_metadata_object = translate(grid_info) | {
+        "spatial_dimension": dim,
+        "coordinate": name,
+        "compression": "none",
+    }
+    metadata = {
+        "zarr_conventions": [convention.convention_metadata],
+        "dggs": dggs_metadata_object,
+    }
+
+    var = xr.Variable(dim, cell_ids)
+    index = xdggs.index.DGGSIndex.from_variables(
+        {name: xr.Variable(dim, cell_ids, grid_info)}, options={}
+    )
+    expected = xr.Coordinates.from_xindex(index).to_dataset()
+
+    obj = xr.Dataset(coords={name: var}, attrs=metadata)
+    orig = obj.copy(deep=True)
+    actual = convention.decode(
+        obj,
+        grid_info=None,
+        name=name,
+        index_options={},
+    )
+    # should not modify the original dataset
+    xr.testing.assert_identical(obj, orig)
+
+    print(obj, actual, expected)
+    xr.testing.assert_identical(actual, expected)
+    assert_indexes_equal(actual[name].xindexes, expected[name].xindexes)
+
+    obj = xr.Dataset(coords={name: (dim, cell_ids)})
+    actual = convention.decode(
+        obj, grid_info=dggs_metadata_object, name=name, index_options={}
+    )
+    xr.testing.assert_identical(actual, expected)
+    assert_indexes_equal(actual[name].xindexes, expected[name].xindexes)
+
+
+@pytest.mark.parametrize(
+    ["name", "dim"], [("cell_ids", "cells"), ("zone_ids", "zones")]
+)
+@pytest.mark.parametrize(
+    ["grid_info", "cell_ids"],
+    (
+        (
+            {"grid_name": "healpix", "level": 1, "indexing_scheme": "nested"},
+            np.array([3, 6, 9], dtype="uint64"),
+        ),
+        (
+            {"grid_name": "h3", "level": 4},
+            np.array([0x832830FFFFFFFFF], dtype="uint64"),
+        ),
+    ),
+)
+def test_encode(grid_info, cell_ids, name, dim):
+    convention = Zarr()
+
+    index_cls = xdggs.index.GRID_REGISTRY[grid_info["grid_name"]]
+    var = xr.Variable(dim, cell_ids, grid_info)
+    index = index_cls.from_variables({name: var}, options={})
+
+    obj = xr.Dataset(coords=xr.Coordinates({name: var}, indexes={name: index}))
+    orig = obj.copy(deep=True)
+
+    coord = obj.dggs.coord
+    dggs_metadata_object = translate(grid_info) | {
+        "spatial_dimension": coord.dims[0],
+        "coordinate": coord.name,
+        "compression": "none",
+    }
+    metadata = {
+        "zarr_conventions": [convention.convention_metadata],
+        "dggs": dggs_metadata_object,
+    }
+    expected = obj.drop_indexes(coord.name).assign_attrs(metadata)
+
+    encoded = convention.encode(obj)
+
+    # should not modify the original dataset
+    xr.testing.assert_identical(obj, orig)
+
+    xr.testing.assert_identical(encoded, expected)
+    assert_indexes_equal(encoded.xindexes, expected.xindexes)

--- a/xdggs/tests/test_conventions_zarr.py
+++ b/xdggs/tests/test_conventions_zarr.py
@@ -4,7 +4,7 @@ import xarray as xr
 
 import xdggs
 from xdggs.conventions.zarr import Zarr
-from xdggs.tests import assert_indexes_equal
+from xdggs.tests import assert_indexes_equal, requires_healpix_geo_0_4_1
 
 
 def translate(mapping):
@@ -193,3 +193,146 @@ def test_encode(grid_info, metadata_object, cell_ids, name, dim):
 
     xr.testing.assert_identical(encoded, expected)
     assert_indexes_equal(encoded.xindexes, expected.xindexes)
+
+
+@pytest.mark.parametrize(
+    ["metadata_object", "encoding", "grid_info", "cell_ids", "encoded"],
+    (
+        pytest.param(
+            {
+                "name": "healpix",
+                "refinement_level": 10,
+                "indexing_scheme": "nested",
+                "coordinate": "cell_ranges",
+                "spatial_dimension": "cells",
+                "compression": "ranges",
+            },
+            {"coordinate": "cell_ranges", "compression": "ranges"},
+            {"grid_name": "healpix", "level": 10, "indexing_scheme": "nested"},
+            xr.Variable(
+                "cells",
+                np.array(
+                    [
+                        112,
+                        113,
+                        114,
+                        115,
+                        116,
+                        117,
+                        118,
+                        119,
+                        120,
+                        121,
+                        122,
+                        123,
+                        124,
+                        125,
+                        126,
+                        127,
+                        1152,
+                        1153,
+                        1154,
+                        1155,
+                        1156,
+                        1157,
+                        1158,
+                        1159,
+                        1160,
+                        1161,
+                        1162,
+                        1163,
+                        1164,
+                        1165,
+                        1166,
+                        1167,
+                    ],
+                    dtype="uint64",
+                ),
+            ),
+            xr.Variable(
+                ("range_index", "bounds"),
+                np.array(
+                    [
+                        [30786325577728, 35184372088832],
+                        [316659348799488, 321057395310592],
+                    ]
+                ),
+            ),
+            id="ranges-10",
+        ),
+        pytest.param(
+            {
+                "name": "healpix",
+                "refinement_level": 2,
+                "indexing_scheme": "nested",
+                "coordinate": "compacted_cell_ids",
+                "spatial_dimension": "cells",
+                "compression": "compacted",
+            },
+            {
+                "coordinate": "compacted_cell_ids",
+                "compression": "compacted",
+                "compacted_level": 1,
+            },
+            {"grid_name": "healpix", "level": 2, "indexing_scheme": "nested"},
+            xr.Variable(
+                "cells",
+                np.array([4, 5, 6, 7, 20, 21, 22, 23, 32, 33, 34, 35]),
+            ),
+            xr.Variable(
+                ("compacted_cells"),
+                np.array([216172782113783808, 792633534417207296, 1224979098644774912]),
+            ),
+            id="compacted_flat-5",
+        ),
+        pytest.param(
+            {
+                "name": "healpix",
+                "refinement_level": 5,
+                "indexing_scheme": "nested",
+                "coordinate": "compacted_cell_ids",
+                "spatial_dimension": "cells",
+                "compression": "compacted",
+            },
+            {"coordinate": "compacted_cell_ids", "compression": "compacted"},
+            {"grid_name": "healpix", "level": 5, "indexing_scheme": "nested"},
+            xr.Variable("cells", np.array([4, 5, 6, 7, 8, 10])),
+            xr.Variable(
+                ("compacted_cells"),
+                np.array([216172782113783808, 306244774661193728, 378302368699121664]),
+            ),
+            marks=requires_healpix_geo_0_4_1,
+            id="compacted-5",
+        ),
+    ),
+)
+def test_encode_compression(metadata_object, encoding, grid_info, cell_ids, encoded):
+    convention = Zarr()
+
+    var = cell_ids.copy()
+    var.attrs = grid_info
+    index = xdggs.index.DGGSIndex.from_variables(
+        {"cell_ids": var},
+        options={
+            "index_kind": "moc",
+        },
+    )
+    ds = xr.Dataset(
+        {"data": ("cells", np.arange(cell_ids.size))},
+        coords=xr.Coordinates.from_xindex(index),
+    )
+
+    name = metadata_object["coordinate"]
+    expected = xr.Dataset(
+        {name: coord.variable for name, coord in ds.data_vars.items()},
+        coords={name: encoded},
+        attrs={
+            "zarr_conventions": [convention.convention_metadata],
+            "dggs": metadata_object,
+        },
+    )
+
+    actual = convention.encode(ds, encoding=encoding)
+
+    xr.testing.assert_equal(actual, expected)
+    assert_indexes_equal(actual.xindexes, expected.xindexes)

--- a/xdggs/tests/test_conventions_zarr.py
+++ b/xdggs/tests/test_conventions_zarr.py
@@ -3,7 +3,7 @@ import pytest
 import xarray as xr
 
 import xdggs
-from xdggs.conventions import Zarr
+from xdggs.conventions.zarr import Zarr
 from xdggs.tests import assert_indexes_equal
 
 
@@ -16,22 +16,24 @@ def translate(mapping):
     ["name", "dim"], [("cell_ids", "cells"), ("zone_ids", "zones")]
 )
 @pytest.mark.parametrize(
-    ["grid_info", "cell_ids"],
+    ["grid_info", "metadata_object", "cell_ids"],
     (
         (
             {"grid_name": "healpix", "level": 1, "indexing_scheme": "nested"},
+            {"name": "healpix", "refinement_level": 1, "indexing_scheme": "nested"},
             np.array([3, 6, 9], dtype="uint64"),
         ),
         (
             {"grid_name": "h3", "level": 4},
+            {"name": "h3", "refinement_level": 4},
             np.array([0x832830FFFFFFFFF], dtype="uint64"),
         ),
     ),
 )
-def test_decode(grid_info, cell_ids, name, dim):
+def test_decode(grid_info, metadata_object, cell_ids, name, dim):
     convention = Zarr()
 
-    dggs_metadata_object = translate(grid_info) | {
+    dggs_metadata_object = metadata_object | {
         "spatial_dimension": dim,
         "coordinate": name,
         "compression": "none",
@@ -68,6 +70,80 @@ def test_decode(grid_info, cell_ids, name, dim):
     )
     xr.testing.assert_identical(actual, expected)
     assert_indexes_equal(actual[name].xindexes, expected[name].xindexes)
+
+
+@pytest.mark.parametrize(
+    ["metadata_object", "grid_info", "variable"],
+    (
+        pytest.param(
+            {
+                "name": "healpix",
+                "refinement_level": 10,
+                "indexing_scheme": "nested",
+                "coordinate": "cell_ranges",
+                "spatial_dimension": "cells",
+                "compression": "ranges",
+            },
+            {"grid_name": "healpix", "level": 10, "indexing_scheme": "nested"},
+            xr.Variable(
+                ("range_index", "bounds"),
+                np.array(
+                    [
+                        [30786325577728, 35184372088832],
+                        [316659348799488, 321057395310592],
+                    ]
+                ),
+            ),
+            id="ranges-10",
+        ),
+        pytest.param(
+            {
+                "name": "healpix",
+                "refinement_level": 5,
+                "indexing_scheme": "nested",
+                "coordinate": "cell_ranges",
+                "spatial_dimension": "cells",
+                "compression": "compacted",
+            },
+            {"grid_name": "healpix", "level": 5, "indexing_scheme": "nested"},
+            xr.Variable(
+                ("compacted_cells"),
+                np.array([216172782113783808, 792633534417207296, 1224979098644774912]),
+            ),
+            id="compacted-5",
+        ),
+    ),
+)
+def test_decode_compression(metadata_object, grid_info, variable):
+    convention = Zarr()
+
+    name = metadata_object["coordinate"]
+    ds = xr.Dataset(
+        coords={name: variable},
+        attrs={
+            "zarr_conventions": [convention.convention_metadata],
+            "dggs": metadata_object,
+        },
+    )
+
+    actual = convention.decode(
+        ds, grid_info=None, name="cell_ids", index_options={"index_kind": "moc"}
+    )
+
+    var = variable.copy()
+    var.attrs = grid_info
+    index = xdggs.index.DGGSIndex.from_variables(
+        {"cell_ids": var},
+        options={
+            "index_kind": "moc",
+            "compression": metadata_object["compression"],
+            "dim": "cells",
+        },
+    )
+    expected = xr.Coordinates.from_xindex(index).to_dataset()
+
+    xr.testing.assert_equal(actual, expected)
+    assert_indexes_equal(actual.xindexes, expected.xindexes)
 
 
 @pytest.mark.parametrize(

--- a/xdggs/tests/test_conventions_zarr.py
+++ b/xdggs/tests/test_conventions_zarr.py
@@ -108,7 +108,10 @@ def test_decode(grid_info, metadata_object, cell_ids, name, dim):
             {"grid_name": "healpix", "level": 5, "indexing_scheme": "nested"},
             xr.Variable(
                 ("compacted_cells"),
-                np.array([216172782113783808, 792633534417207296, 1224979098644774912]),
+                np.array(
+                    [216172782113783808, 792633534417207296, 1224979098644774912],
+                    dtype="uint64",
+                ),
             ),
             id="compacted-5",
         ),
@@ -283,7 +286,7 @@ def test_encode(grid_info, metadata_object, cell_ids, name, dim):
                 ("compacted_cells"),
                 np.array([216172782113783808, 792633534417207296, 1224979098644774912]),
             ),
-            id="compacted_flat-5",
+            id="compacted_flat-2",
         ),
         pytest.param(
             {
@@ -296,10 +299,22 @@ def test_encode(grid_info, metadata_object, cell_ids, name, dim):
             },
             {"coordinate": "compacted_cell_ids", "compression": "compacted"},
             {"grid_name": "healpix", "level": 5, "indexing_scheme": "nested"},
-            xr.Variable("cells", np.array([4, 5, 6, 7, 8, 10])),
+            xr.Variable(
+                "cells",
+                np.array([4, 5, 6, 7, 8, 10, 12, *range(16, 32)], dtype="uint64"),
+            ),
             xr.Variable(
                 ("compacted_cells"),
-                np.array([216172782113783808, 306244774661193728, 378302368699121664]),
+                np.array(
+                    [
+                        3377699720527872,
+                        4785074604081152,
+                        5910974510923776,
+                        7036874417766400,
+                        13510798882111488,
+                    ],
+                    dtype="uint64",
+                ),
             ),
             marks=requires_healpix_geo_0_4_1,
             id="compacted-5",

--- a/xdggs/tests/test_healpix.py
+++ b/xdggs/tests/test_healpix.py
@@ -667,7 +667,7 @@ class TestHealpixIndex:
         strategies.grids(),
     )
     def test_init(self, cell_ids, dim, name, grid) -> None:
-        index = healpix.HealpixIndex(cell_ids, dim, name, grid)
+        index = healpix.HealpixIndex(cell_ids, dim=dim, name=name, grid_info=grid)
 
         assert index._grid == grid
         assert index._dim == dim
@@ -707,6 +707,39 @@ def test_from_variables_moc() -> None:
 
     index = healpix.HealpixIndex.from_variables(
         variables, options={"index_kind": "moc"}
+    )
+
+    assert isinstance(index._index, healpix.HealpixMocIndex)
+    assert index.grid_info.to_dict() == grid_info
+
+
+def test_from_variables_moc_ranges() -> None:
+    level = 16
+    grid_info = {"grid_name": "healpix", "level": level, "indexing_scheme": "nested"}
+    variables = {
+        "cell_ids": xr.Variable(
+            ["cells", "ranges"],
+            np.array(
+                [
+                    [30786325577728, 35184372088832],
+                    [35184372088832, 39582418599936],
+                    [39582418599936, 43980465111040],
+                    [299067162755072, 303465209266176],
+                    [303465209266176, 307863255777280],
+                    [307863255777280, 312261302288384],
+                    [312261302288384, 316659348799488],
+                    [316659348799488, 321057395310592],
+                    [321057395310592, 325455441821696],
+                    [325455441821696, 329853488332800],
+                ],
+                dtype="uint64",
+            ),
+            grid_info,
+        )
+    }
+
+    index = healpix.HealpixIndex.from_variables(
+        variables, options={"index_kind": "moc", "compression": "ranges"}
     )
 
     assert isinstance(index._index, healpix.HealpixMocIndex)

--- a/xdggs/tests/test_healpix_moc_index.py
+++ b/xdggs/tests/test_healpix_moc_index.py
@@ -8,53 +8,182 @@ from xdggs.tests import da, raise_if_dask_computes, requires_dask
 
 class TestHealpixMocIndex:
     @pytest.mark.parametrize(
-        ["level", "cell_ids", "max_computes"],
+        [
+            "level",
+            "cell_ids",
+            "compression",
+            "expected_size",
+            "expected_nbytes",
+            "max_computes",
+        ],
         (
             pytest.param(
-                2, np.arange(12 * 4**2, dtype="uint64"), 1, id="numpy-2-full_domain"
+                2,
+                np.arange(12 * 4**2, dtype="uint64"),
+                "none",
+                12 * 4**2,
+                16,
+                1,
+                id="numpy-2-full_domain-none",
             ),
             pytest.param(
                 2,
                 np.arange(3 * 4**2, 5 * 4**2, dtype="uint64"),
+                "none",
+                2 * 4**2,
+                16,
                 1,
-                id="numpy-2-region",
+                id="numpy-2-region-none",
             ),
             pytest.param(
                 10,
                 da.arange(12 * 4**10, chunks=(4**6,), dtype="uint64"),
+                "none",
+                12 * 4**10,
+                16,
                 0,
                 marks=requires_dask,
-                id="dask-10-full_domain",
+                id="dask-10-full_domain-none",
             ),
             pytest.param(
                 15,
                 da.arange(12 * 4**15, chunks=(4**10,), dtype="uint64"),
+                "none",
+                12 * 4**15,
+                16,
                 0,
                 marks=requires_dask,
-                id="dask-15-full_domain",
+                id="dask-15-full_domain-none",
             ),
             pytest.param(
                 10,
                 da.arange(3 * 4**10, 5 * 4**10, chunks=(4**6,), dtype="uint64"),
+                "none",
+                2 * 4**10,
+                16,
                 1,
                 marks=requires_dask,
-                id="dask-10-region",
+                id="dask-10-region-none",
+            ),
+            pytest.param(
+                15,
+                np.array(
+                    [
+                        65970697666560,
+                        74766790688768,
+                        83562883710976,
+                        602532372021248,
+                        611328465043456,
+                        620124558065664,
+                        628920651087872,
+                        637716744110080,
+                        646512837132288,
+                        655308930154496,
+                    ],
+                    dtype="uint64",
+                ),
+                "compacted",
+                10 * 4**7,
+                32,
+                0,
+                id="numpy-15-region-compacted",
+            ),
+            pytest.param(
+                15,
+                da.from_array(
+                    np.array(
+                        [
+                            65970697666560,
+                            74766790688768,
+                            83562883710976,
+                            602532372021248,
+                            611328465043456,
+                            620124558065664,
+                            628920651087872,
+                            637716744110080,
+                            646512837132288,
+                            655308930154496,
+                        ],
+                        dtype="uint64",
+                    ),
+                    chunks=(2,),
+                ),
+                "compacted",
+                10 * 4**7,
+                32,
+                1,
+                id="dask-15-region-compacted",
+            ),
+            pytest.param(
+                15,
+                np.array(
+                    [
+                        [30786325577728, 35184372088832],
+                        [35184372088832, 39582418599936],
+                        [39582418599936, 43980465111040],
+                        [299067162755072, 303465209266176],
+                        [303465209266176, 307863255777280],
+                        [307863255777280, 312261302288384],
+                        [312261302288384, 316659348799488],
+                        [316659348799488, 321057395310592],
+                        [321057395310592, 325455441821696],
+                        [325455441821696, 329853488332800],
+                    ],
+                    dtype="uint64",
+                ),
+                "ranges",
+                10 * 4**7,
+                32,
+                0,
+                id="numpy-15-region-ranges",
+            ),
+            pytest.param(
+                15,
+                da.from_array(
+                    np.array(
+                        [
+                            [30786325577728, 35184372088832],
+                            [35184372088832, 39582418599936],
+                            [39582418599936, 43980465111040],
+                            [299067162755072, 303465209266176],
+                            [303465209266176, 307863255777280],
+                            [307863255777280, 312261302288384],
+                            [312261302288384, 316659348799488],
+                            [316659348799488, 321057395310592],
+                            [321057395310592, 325455441821696],
+                            [325455441821696, 329853488332800],
+                        ],
+                        dtype="uint64",
+                    ),
+                    chunks=(2, 2),
+                ),
+                "ranges",
+                10 * 4**7,
+                32,
+                1,
+                id="dask-15-region-ranges",
             ),
         ),
     )
-    def test_from_array(self, level, cell_ids, max_computes):
+    def test_from_array(
+        self, level, cell_ids, compression, expected_size, expected_nbytes, max_computes
+    ):
         grid_info = healpix.HealpixInfo(level=level, indexing_scheme="nested")
 
         with raise_if_dask_computes(max_computes=max_computes):
             index = healpix.HealpixMocIndex.from_array(
-                cell_ids, dim="cells", name="cell_ids", grid_info=grid_info
+                cell_ids,
+                dim="cells",
+                name="cell_ids",
+                grid_info=grid_info,
+                compression=compression,
             )
 
         assert isinstance(index, healpix.HealpixMocIndex)
         chunks = index.chunksizes["cells"]
         assert chunks is None or isinstance(chunks[0], int)
-        assert index.size == cell_ids.size
-        assert index.nbytes == 16
+        assert index.size == expected_size
+        assert index.nbytes == expected_nbytes
 
     def test_from_array_unsupported_indexing_scheme(self):
         level = 1

--- a/xdggs/typing.py
+++ b/xdggs/typing.py
@@ -1,3 +1,4 @@
 from typing import Literal
 
 Compression = Literal["none", "compacted", "ranges"]
+TranslationTable = dict[str, str | dict[str, str]]

--- a/xdggs/utils.py
+++ b/xdggs/utils.py
@@ -37,10 +37,7 @@ def ignore_parameters(*names):
     return inner
 
 
-def call_on_dataset(func, obj, *args, kwargs=None):
-    if kwargs is None:
-        kwargs = {}
-
+def call_on_dataset(func, obj, *args, **kwargs):
     if isinstance(obj, xr.DataArray):
         ds = obj._to_temp_dataset()
     else:


### PR DESCRIPTION
- [x] towards #143
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `changelog.md`
- [ ] New functions/methods are listed in `api.rst`

The zarr dggs convention supports compressing the spatial coordinate as compacted cell ids (in zuniq) or directly as the connected ranges. Additionally, the `healpix-geo`'s RangeMOCIndex supports reading those, so all we need to do here is connect the two.

I realize this also touches what #260 is doing (ellipsoid parameter name translation), so I'd expect merge conflicts.