### PR TITLE
drop cdshealpix from the dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
 
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        env: ["ci-py312", "ci-py314"]
+        env: ["ci-py312", "ci-py313"]
 
     steps:
       - name: Clone repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
 
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        env: ["ci-py312", "ci-py313"]
+        env: ["ci-py312", "ci-py313", "ci-py314"]
 
     steps:
       - name: Clone repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
 
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        env: ["ci-py312", "ci-py313", "ci-py314"]
+        env: ["ci-py312", "ci-py314"]
 
     steps:
       - name: Clone repository

--- a/ci/nightly/pixi.toml
+++ b/ci/nightly/pixi.toml
@@ -28,9 +28,7 @@ numpy = "*"
 pandas = "*"
 pyarrow = "*"
 h3ronpy = { git = "git+https://github.com/nmandery/h3ronpy.git", subdirectory = "h3ronpy" }
-cdshealpix = { git = "git+https://github.com/cds-astro/cds-healpix-python.git" }
 healpix-geo = { git = "git+https://github.com/eopf-dggs/healpix-geo.git", subdirectory = "python/healpix-geo" }
-astropy = { git = "git+https://github.com/astropy/astropy.git" }
 lonboard = ">=0.14.0"
 
 [feature.tests.dependencies]

--- a/ci/nightly/pixi.toml
+++ b/ci/nightly/pixi.toml
@@ -28,7 +28,7 @@ numpy = "*"
 pandas = "*"
 pyarrow = "*"
 h3ronpy = { git = "git+https://github.com/nmandery/h3ronpy.git", subdirectory = "h3ronpy" }
-healpix-geo = { git = "git+https://github.com/eopf-dggs/healpix-geo.git", subdirectory = "python/healpix-geo" }
+healpix-geo = { git = "git+https://github.com/grid4earth/healpix-geo.git", subdirectory = "healpix-geo-python" }
 lonboard = ">=0.14.0"
 
 [feature.tests.dependencies]

--- a/pixi.toml
+++ b/pixi.toml
@@ -60,8 +60,9 @@ python = "3.12.*"
 [feature.py313.dependencies]
 python = "3.13.*"
 
-[feature.py314.dependencies]
-python = "3.14.*"
+# h3ronpy is not yet compatible with python 3.14
+# [feature.py314.dependencies]
+# python = "3.14.*"
 
 [feature.docs.dependencies]
 sphinx = "<9"
@@ -111,7 +112,7 @@ nightly-tests = { cmd = "pixi run --manifest-path ci/nightly/pixi.toml tests", c
 [environments]
 ci-py312 = { features = ["tests", "py312"] }
 ci-py313 = { features = ["tests", "py313"] }
-ci-py314 = { features = ["tests", "py314"] }
-docs = { features = ["docs", "py314"] }
-default = { features = ["tests", "dev", "py314"] }
+# ci-py314 = { features = ["tests", "py314"] }
+docs = { features = ["docs", "py313"] }
+default = { features = ["tests", "dev", "py313"] }
 ci = { features = ["ci"], no-default-feature = true }

--- a/pixi.toml
+++ b/pixi.toml
@@ -39,7 +39,6 @@ anywidget = ">=0.11.0"
 
 [dependencies]
 xdggs = { path = "." }
-cdshealpix = ">=0.7.1"
 
 [feature.tests.dependencies]
 pytest = "*"

--- a/pixi.toml
+++ b/pixi.toml
@@ -64,7 +64,6 @@ python = "3.13.*"
 python = "3.14.*"
 
 [feature.docs.dependencies]
-python = "3.13.*"
 sphinx = "<9"
 myst-nb = "*"
 sphinx-book-theme = "*"
@@ -85,7 +84,6 @@ autobuild-docs = { cmd = "sphinx-autobuild -b html -w warnings.log -W -Tn -j aut
 build-docs-rtd = { cmd = "python -m sphinx -b html -W -T -j auto . $READTHEDOCS_OUTPUT/html", cwd = "docs" }
 
 [feature.dev.dependencies]
-python = "3.13.*"
 ipython = "*"
 black = "*"
 isort = "*"
@@ -114,6 +112,6 @@ nightly-tests = { cmd = "pixi run --manifest-path ci/nightly/pixi.toml tests", c
 ci-py312 = { features = ["tests", "py312"] }
 ci-py313 = { features = ["tests", "py313"] }
 ci-py314 = { features = ["tests", "py314"] }
-docs = { features = ["docs"] }
-default = { features = ["tests", "dev"] }
+docs = { features = ["docs", "py314"] }
+default = { features = ["tests", "dev", "py314"] }
 ci = { features = ["ci"], no-default-feature = true }

--- a/pixi.toml
+++ b/pixi.toml
@@ -60,6 +60,9 @@ python = "3.12.*"
 [feature.ci-py313.dependencies]
 python = "3.13.*"
 
+[feature.ci-py314.dependencies]
+python = "3.13.*"
+
 [feature.docs.dependencies]
 python = "3.13.*"
 sphinx = "<9"
@@ -110,6 +113,7 @@ nightly-tests = { cmd = "pixi run --manifest-path ci/nightly/pixi.toml tests", c
 [environments]
 ci-py312 = { features = ["tests", "ci-py312"] }
 ci-py313 = { features = ["tests", "ci-py313"] }
+ci-py314 = { features = ["tests", "ci-py314"] }
 docs = { features = ["docs"] }
 default = { features = ["tests", "dev"] }
 ci = { features = ["ci"], no-default-feature = true }

--- a/pixi.toml
+++ b/pixi.toml
@@ -54,14 +54,14 @@ dask = ">=2025.7.0"
 tests = { cmd = "pytest -n auto --cov=xdggs", cwd = ".", default-environment = "default" }
 doctests = { cmd = "pytest --doctest-modules xdggs --ignore xdggs/tests", cwd = "." }
 
-[feature.ci-py312.dependencies]
+[feature.py312.dependencies]
 python = "3.12.*"
 
-[feature.ci-py313.dependencies]
+[feature.py313.dependencies]
 python = "3.13.*"
 
-[feature.ci-py314.dependencies]
-python = "3.13.*"
+[feature.py314.dependencies]
+python = "3.14.*"
 
 [feature.docs.dependencies]
 python = "3.13.*"
@@ -111,9 +111,9 @@ python = "*"
 nightly-tests = { cmd = "pixi run --manifest-path ci/nightly/pixi.toml tests", cwd = "." }
 
 [environments]
-ci-py312 = { features = ["tests", "ci-py312"] }
-ci-py313 = { features = ["tests", "ci-py313"] }
-ci-py314 = { features = ["tests", "ci-py314"] }
+ci-py312 = { features = ["tests", "py312"] }
+ci-py313 = { features = ["tests", "py313"] }
+ci-py314 = { features = ["tests", "py314"] }
 docs = { features = ["docs"] }
 default = { features = ["tests", "dev"] }
 ci = { features = ["ci"], no-default-feature = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
   "xarray",
   "numpy>=2.0",
   "cdshealpix",
-  "healpix-geo>=0.0.9",
+  "healpix-geo>=0.3.0",
   "h3ronpy",
   "lonboard>=0.9.3",
   "pyproj>=3.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ requires-python = ">=3.12"
 dependencies = [
   "xarray",
   "numpy>=2.0",
-  "cdshealpix",
   "healpix-geo>=0.3.0",
   "h3ronpy",
   "lonboard>=0.9.3",

--- a/xdggs/tests/test_healpix.py
+++ b/xdggs/tests/test_healpix.py
@@ -402,8 +402,7 @@ class TestHealpixInfo:
 
     @given(
         *strategies.grid_and_cell_ids(
-            # a dtype casting bug in the valid range check of `cdshealpix`
-            # causes this test to fail for large levels
+            # use small levels for quicker tests
             levels=st.integers(min_value=0, max_value=10),
             indexing_schemes=st.sampled_from(["nested", "ring"]),
             dtypes=st.sampled_from(["int64"]),


### PR DESCRIPTION
`healpix-geo` has reached the point where it can fully replace `cdshealpix-python`, getting rid of the astropy dependency.

~~This also allows us to run CI on python 3.14.~~ actually, that's wrong, we still need a release from `h3ronpy`.